### PR TITLE
add cache refresh

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -13,7 +13,15 @@ container:
   image: python:3.8
 
 env:
-  PIP_CACHE_VERSION: "1"
+  # Maximum cache age in weeks before forcing a new cache upload.
+  CACHE_AGE: "2"
+  # Increment the build number to force new conda cache upload.
+  CONDA_CACHE_BUILD: "0"
+  # Increment the build number to force new nox cache upload.
+  NOX_CACHE_BUILD: "0"
+  # Increment the build number to force new pip cache upload.
+  PIP_CACHE_BUILD: "0"
+  # Pip package to be upgraded/installed.
   PIP_CACHE_PACKAGES: "pip setuptools wheel nox"
 
 
@@ -27,10 +35,11 @@ lint_task:
     folder: ~/.cache/pip
     fingerprint_script:
       - echo "${CIRRUS_OS} py${PYTHON_VERSION}"
-      - echo "v${PIP_CACHE_VERSION} ${PIP_CACHE_PACKAGES}"
+      - echo "$(date +%Y).$(($(date +%U) / ${CACHE_AGE})):${PIP_CACHE_BUILD} ${PIP_CACHE_PACKAGES}"
   lint_script:
     - pip list
     - python -m pip install --retries 3 --upgrade ${PIP_CACHE_PACKAGES}
+    - pip list
     - nox --session lint
 
 
@@ -44,10 +53,11 @@ style_task:
     folder: ~/.cache/pip
     fingerprint_script:
       - echo "${CIRRUS_OS} py${PYTHON_VERSION}"
-      - echo "v${PIP_CACHE_VERSION} ${PIP_CACHE_PACKAGES}"
+      - echo "$(date +%Y).$(($(date +%U) / ${CACHE_AGE})):${PIP_CACHE_BUILD} ${PIP_CACHE_PACKAGES}"
   style_script:
     - pip list
     - python -m pip install --retries 3 --upgrade ${PIP_CACHE_PACKAGES}
+    - pip list
     - nox --session style
 
 
@@ -73,6 +83,7 @@ linux_task:
     fingerprint_script:
       - wget --quiet https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
       - echo "${CIRRUS_OS} $(sha256sum miniconda.sh)"
+      - echo "$(date +%Y).$(($(date +%U) / ${CACHE_AGE})):${CONDA_CACHE_BUILD}"
     populate_script:
       - bash miniconda.sh -b -p ${HOME}/miniconda
       - conda config --set always_yes yes --set changeps1 no
@@ -88,6 +99,7 @@ linux_task:
     folder: ${CIRRUS_WORKING_DIR}/.nox
     fingerprint_script:
       - echo "${CIRRUS_OS} tests ${PY_VER}"
+      - echo "$(date +%Y).$(($(date +%U) / ${CACHE_AGE})):${NOX_CACHE_BUILD}"
       - cat ${CIRRUS_WORKING_DIR}/requirements/py$(echo ${PY_VER} | tr -d ".").yml
   test_script:
     - nox --session tests
@@ -111,6 +123,7 @@ osx_task:
     fingerprint_script:
       - wget --quiet https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh -O miniconda.sh
       - echo "${CIRRUS_OS} $(shasum -a 256 miniconda.sh)"
+      - echo "$(date +%Y).$(($(date +%U) / ${CACHE_AGE})):${CONDA_CACHE_BUILD}"
     populate_script:
       - bash miniconda.sh -b -p ${HOME}/miniconda
       - conda config --set always_yes yes --set changeps1 no
@@ -126,6 +139,7 @@ osx_task:
     folder: ${CIRRUS_WORKING_DIR}/.nox
     fingerprint_script:
       - echo "${CIRRUS_OS} tests ${PY_VER}"
+      - echo "$(date +%Y).$(($(date +%U) / ${CACHE_AGE})):${NOX_CACHE_BUILD}"
       - cat ${CIRRUS_WORKING_DIR}/requirements/py$(echo ${PY_VER} | tr -d ".").yml
   test_script:
     - nox --session tests

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -13,8 +13,8 @@ container:
   image: python:3.8
 
 env:
-  # Maximum cache age in weeks before forcing a new cache upload.
-  CACHE_AGE: "2"
+  # Maximum cache period (in weeks) before forcing a new cache upload.
+  CACHE_PERIOD: "2"
   # Increment the build number to force new conda cache upload.
   CONDA_CACHE_BUILD: "0"
   # Increment the build number to force new nox cache upload.
@@ -35,7 +35,7 @@ lint_task:
     folder: ~/.cache/pip
     fingerprint_script:
       - echo "${CIRRUS_OS} py${PYTHON_VERSION}"
-      - echo "$(date +%Y).$(($(date +%U) / ${CACHE_AGE})):${PIP_CACHE_BUILD} ${PIP_CACHE_PACKAGES}"
+      - echo "$(date +%Y).$(($(date +%U) / ${CACHE_PERIOD})):${PIP_CACHE_BUILD} ${PIP_CACHE_PACKAGES}"
   lint_script:
     - pip list
     - python -m pip install --retries 3 --upgrade ${PIP_CACHE_PACKAGES}
@@ -53,7 +53,7 @@ style_task:
     folder: ~/.cache/pip
     fingerprint_script:
       - echo "${CIRRUS_OS} py${PYTHON_VERSION}"
-      - echo "$(date +%Y).$(($(date +%U) / ${CACHE_AGE})):${PIP_CACHE_BUILD} ${PIP_CACHE_PACKAGES}"
+      - echo "$(date +%Y).$(($(date +%U) / ${CACHE_PERIOD})):${PIP_CACHE_BUILD} ${PIP_CACHE_PACKAGES}"
   style_script:
     - pip list
     - python -m pip install --retries 3 --upgrade ${PIP_CACHE_PACKAGES}
@@ -83,7 +83,7 @@ linux_task:
     fingerprint_script:
       - wget --quiet https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
       - echo "${CIRRUS_OS} $(sha256sum miniconda.sh)"
-      - echo "$(date +%Y).$(($(date +%U) / ${CACHE_AGE})):${CONDA_CACHE_BUILD}"
+      - echo "$(date +%Y).$(($(date +%U) / ${CACHE_PERIOD})):${CONDA_CACHE_BUILD}"
     populate_script:
       - bash miniconda.sh -b -p ${HOME}/miniconda
       - conda config --set always_yes yes --set changeps1 no
@@ -99,7 +99,7 @@ linux_task:
     folder: ${CIRRUS_WORKING_DIR}/.nox
     fingerprint_script:
       - echo "${CIRRUS_OS} tests ${PY_VER}"
-      - echo "$(date +%Y).$(($(date +%U) / ${CACHE_AGE})):${NOX_CACHE_BUILD}"
+      - echo "$(date +%Y).$(($(date +%U) / ${CACHE_PERIOD})):${NOX_CACHE_BUILD}"
       - cat ${CIRRUS_WORKING_DIR}/requirements/py$(echo ${PY_VER} | tr -d ".").yml
   test_script:
     - nox --session tests
@@ -123,7 +123,7 @@ osx_task:
     fingerprint_script:
       - wget --quiet https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh -O miniconda.sh
       - echo "${CIRRUS_OS} $(shasum -a 256 miniconda.sh)"
-      - echo "$(date +%Y).$(($(date +%U) / ${CACHE_AGE})):${CONDA_CACHE_BUILD}"
+      - echo "$(date +%Y).$(($(date +%U) / ${CACHE_PERIOD})):${CONDA_CACHE_BUILD}"
     populate_script:
       - bash miniconda.sh -b -p ${HOME}/miniconda
       - conda config --set always_yes yes --set changeps1 no
@@ -139,7 +139,7 @@ osx_task:
     folder: ${CIRRUS_WORKING_DIR}/.nox
     fingerprint_script:
       - echo "${CIRRUS_OS} tests ${PY_VER}"
-      - echo "$(date +%Y).$(($(date +%U) / ${CACHE_AGE})):${NOX_CACHE_BUILD}"
+      - echo "$(date +%Y).$(($(date +%U) / ${CACHE_PERIOD})):${NOX_CACHE_BUILD}"
       - cat ${CIRRUS_WORKING_DIR}/requirements/py$(echo ${PY_VER} | tr -d ".").yml
   test_script:
     - nox --session tests


### PR DESCRIPTION
This PR adds two levels of control to force a refresh of `cirrus-ci` task caches:
1. Incorporate the `date` year `+%Y`, and week number `+%U` as part of a cache `fingerprint`, and using the `CACHE_AGE` on the week number to partition the week number into like week periods - for automated refreshes
1. Use the `X_CACHE_BUILD` number as part of a cache `fingerprint` to force a cache upload - for manual refreshes

The expected typical use case for bumping the cache build number would be to force a cache upload within a `CACHE_AGE` period. The build number should then be reset after the `CACHE_AGE` period has elapsed.