### PR TITLE
Add support for masked data

### DIFF
--- a/esmf_regrid/esmf_regridder.py
+++ b/esmf_regrid/esmf_regridder.py
@@ -31,7 +31,14 @@ class GridInfo:
     # TODO: Edit GridInfo so that it is able to handle 2D lat/lon arrays.
 
     def __init__(
-        self, lons, lats, lonbounds, latbounds, crs=None, circular=False, areas=None,
+        self,
+        lons,
+        lats,
+        lonbounds,
+        latbounds,
+        crs=None,
+        circular=False,
+        areas=None,
     ):
         """
         Create a GridInfo object describing the grid.
@@ -120,7 +127,11 @@ class GridInfo:
 
         if circular:
             grid = ESMF.Grid(
-                shape, pole_kind=[1, 1], num_peri_dims=1, periodic_dim=1, pole_dim=0,
+                shape,
+                pole_kind=[1, 1],
+                num_peri_dims=1,
+                periodic_dim=1,
+                pole_dim=0,
             )
         else:
             grid = ESMF.Grid(shape, pole_kind=[1, 1])
@@ -249,7 +260,8 @@ class Regridder:
                 msg = "Expected precomputed weights to have shape {}, got shape {} instead."
                 raise ValueError(
                     msg.format(
-                        (self.tgt.size(), self.src.size()), precomputed_weights.shape,
+                        (self.tgt.size(), self.src.size()),
+                        precomputed_weights.shape,
                     )
                 )
             self.weight_matrix = precomputed_weights

--- a/esmf_regrid/esmf_regridder.py
+++ b/esmf_regrid/esmf_regridder.py
@@ -301,12 +301,11 @@ class Regridder:
         mdtol = max(mdtol, 1e-8)
         tgt_mask = weight_sums > 1 - mdtol
         masked_weight_sums = weight_sums * tgt_mask
+        normalisations = np.ones(self.tgt.size())
         if norm_type == "fracarea":
-            normalisations = 1 / np.where(
-                masked_weight_sums == 0.0, 1.0, masked_weight_sums
-            )
+            normalisations[tgt_mask] /= masked_weight_sums[tgt_mask]
         elif norm_type == "dstarea":
-            normalisations = np.ones(self.tgt.size())
+            pass
         else:
             raise ValueError(f'Normalisation type "{norm_type}" is not supported')
         normalisations = ma.array(normalisations, mask=np.logical_not(tgt_mask))

--- a/esmf_regrid/esmf_regridder.py
+++ b/esmf_regrid/esmf_regridder.py
@@ -266,7 +266,7 @@ class Regridder:
                 )
             self.weight_matrix = precomputed_weights
 
-    def regrid(self, src_array, norm_type="FRACAREA", mdtol=1):
+    def regrid(self, src_array, norm_type="fracarea", mdtol=1):
         """
         Perform regridding on an array of data.
 
@@ -274,15 +274,19 @@ class Regridder:
         ----------
         src_array : array_like
             A numpy array whose shape is compatible with self.src
-        mdtol : int, optional
+        norm_type : string
+            Either "fracarea" or "dstarea", defaults to "fracarea". Determines the
+            type of normalisation applied to the weights. Normalisations correspond
+            to ESMF constants ESMF.NormType.FRACAREA and ESMF.NormType.DSTAREA.
+        mdtol : float, optional
             A number between 0 and 1 describing the missing data tolerance.
-            Depending on the value of mdtol, if an element in the target mesh/grid
-            is not sufficiently covered by elements of the source mesh/grid, then
-            the corresponding data point will be masked. An mdtol of 1 means that
-            only target elements which are completely uncovered will be masked,
-            an mdtol of 0 means that only target elements which are completely
-            covered will be unmasked and an mdtol of 0.5 means that target elements
-            whose area is at least half uncovered by source elements will be masked.
+            Depending on the value of `mdtol`, if a cell in the target grid is not
+            sufficiently covered by unmasked cells of the source grid, then it will
+            be masked. An `mdtol` of 1 means that only target cells which are not
+            covered at all will be masked, an `mdtol` of 0 means that all target
+            cells that are not entirely covered will be masked, and an `mdtol` of
+            0.5 means that all target cells that are less than half covered will
+            be masked.
 
         Returns
         -------
@@ -290,25 +294,24 @@ class Regridder:
             A numpy array whose shape is compatible with self.tgt.
 
         """
-        src_inverted_mask = np.where(ma.getmaskarray(src_array), 0, 1)
-        src_inverted_mask = self.src._flatten_array(src_inverted_mask)
+        src_inverted_mask = self.src._flatten_array(~ma.getmaskarray(src_array))
         weight_sums = self.weight_matrix * src_inverted_mask
         # Set the minimum mdtol to be slightly higher than 0 to account for rounding
         # errors.
         mdtol = max(mdtol, 1e-8)
         tgt_mask = weight_sums > 1 - mdtol
-        masked_weight_sums = weight_sums * tgt_mask.astype(int)
-        if norm_type == "FRACAREA":
-            normalisations = np.where(
-                masked_weight_sums == 0, 0, 1 / masked_weight_sums
+        masked_weight_sums = weight_sums * tgt_mask
+        if norm_type == "fracarea":
+            normalisations = 1 / np.where(
+                masked_weight_sums == 0.0, 1.0, masked_weight_sums
             )
-        elif norm_type == "DSTAREA":
+        elif norm_type == "dstarea":
             normalisations = np.ones(self.tgt.size())
         else:
             raise ValueError(f'Normalisation type "{norm_type}" is not supported')
         normalisations = ma.array(normalisations, mask=np.logical_not(tgt_mask))
 
-        flat_src = self.src._flatten_array(ma.getdata(src_array)) * src_inverted_mask
+        flat_src = self.src._flatten_array(ma.filled(src_array, 0.0))
         flat_tgt = self.weight_matrix * flat_src
         flat_tgt = flat_tgt * normalisations
         tgt_array = self.tgt._unflatten_array(flat_tgt)

--- a/esmf_regrid/esmf_regridder.py
+++ b/esmf_regrid/esmf_regridder.py
@@ -31,14 +31,7 @@ class GridInfo:
     # TODO: Edit GridInfo so that it is able to handle 2D lat/lon arrays.
 
     def __init__(
-        self,
-        lons,
-        lats,
-        lonbounds,
-        latbounds,
-        crs=None,
-        circular=False,
-        areas=None,
+        self, lons, lats, lonbounds, latbounds, crs=None, circular=False, areas=None,
     ):
         """
         Create a GridInfo object describing the grid.
@@ -127,11 +120,7 @@ class GridInfo:
 
         if circular:
             grid = ESMF.Grid(
-                shape,
-                pole_kind=[1, 1],
-                num_peri_dims=1,
-                periodic_dim=1,
-                pole_dim=0,
+                shape, pole_kind=[1, 1], num_peri_dims=1, periodic_dim=1, pole_dim=0,
             )
         else:
             grid = ESMF.Grid(shape, pole_kind=[1, 1])
@@ -260,8 +249,7 @@ class Regridder:
                 msg = "Expected precomputed weights to have shape {}, got shape {} instead."
                 raise ValueError(
                     msg.format(
-                        (self.tgt.size(), self.src.size()),
-                        precomputed_weights.shape,
+                        (self.tgt.size(), self.src.size()), precomputed_weights.shape,
                     )
                 )
             self.weight_matrix = precomputed_weights
@@ -301,11 +289,13 @@ class Regridder:
         tgt_mask = weight_sums > 1 - mdtol
         masked_weight_sums = weight_sums * tgt_mask.astype(int)
         if norm_type == "FRACAREA":
-            normalisations = np.where(masked_weight_sums == 0, 0, 1 / masked_weight_sums)
+            normalisations = np.where(
+                masked_weight_sums == 0, 0, 1 / masked_weight_sums
+            )
         elif norm_type == "DSTAREA":
             normalisations = np.ones(self.tgt.size())
         else:
-            raise ValueError(f"Normalisation type \"{norm_type}\" is not supported")
+            raise ValueError(f'Normalisation type "{norm_type}" is not supported')
         normalisations = ma.array(normalisations, mask=np.logical_not(tgt_mask))
 
         flat_src = self.src._flatten_array(ma.getdata(src_array))

--- a/esmf_regrid/esmf_regridder.py
+++ b/esmf_regrid/esmf_regridder.py
@@ -266,7 +266,7 @@ class Regridder:
                 )
             self.weight_matrix = precomputed_weights
 
-    def regrid(self, src_array, mdtol=1):
+    def regrid(self, src_array, norm_type="FRACAREA", mdtol=1):
         """
         Perform regridding on an array of data.
 
@@ -290,16 +290,8 @@ class Regridder:
             A numpy array whose shape is compatible with self.tgt.
 
         """
-        # A rudimentary filter is applied to mask data which is mapped from an
-        # insufficiently large source. This currently only accounts for discrepancies
-        # between the source and target grid/mesh geometries and does not account for
-        # masked data, though it ought to be possible to extend the functionality to
-        # handle masked data.
-        #
-        # Note that ESMPy is also able to handle masked data. It is worth investigating
-        # how this affects the mathematics and if it can be replicated after the fact
-        # using just the weights or if ESMF is doing something we want access to.
         src_inverted_mask = np.where(ma.getmaskarray(src_array), 0, 1)
+        src_inverted_mask = self.src._flatten_array(src_inverted_mask)
         src_mask_matrix = scipy.sparse.diags(src_inverted_mask)
         masked_weights = self.weight_matrix * src_mask_matrix
         weight_sums = np.array(masked_weights.sum(axis=1)).flatten()
@@ -308,11 +300,16 @@ class Regridder:
         mdtol = max(mdtol, 1e-8)
         tgt_mask = weight_sums >= 1 - mdtol
         masked_weight_sums = weight_sums * tgt_mask.astype(int)
-        normalisations = np.where(masked_weight_sums == 0, 0, 1 / masked_weight_sums)
+        if norm_type == "FRACAREA":
+            normalisations = np.where(masked_weight_sums == 0, 0, 1 / masked_weight_sums)
+        elif norm_type == "DSTAREA":
+            normalisations = np.ones(self.tgt.size())
+        else:
+            raise ValueError(f"Normalisation type \"{norm_type}\" is not supported")
         normalisations = ma.array(normalisations, mask=np.logical_not(tgt_mask))
 
         flat_src = self.src._flatten_array(ma.getdata(src_array))
-        flat_tgt = self.weight_matrix * flat_src
+        flat_tgt = masked_weights * flat_src
         flat_tgt = flat_tgt * normalisations
         tgt_array = self.tgt._unflatten_array(flat_tgt)
         return tgt_array

--- a/esmf_regrid/esmf_regridder.py
+++ b/esmf_regrid/esmf_regridder.py
@@ -298,7 +298,7 @@ class Regridder:
         # Set the minimum mdtol to be slightly higher than 0 to account for rounding
         # errors.
         mdtol = max(mdtol, 1e-8)
-        tgt_mask = weight_sums >= 1 - mdtol
+        tgt_mask = weight_sums > 1 - mdtol
         masked_weight_sums = weight_sums * tgt_mask.astype(int)
         if norm_type == "FRACAREA":
             normalisations = np.where(masked_weight_sums == 0, 0, 1 / masked_weight_sums)

--- a/esmf_regrid/esmf_regridder.py
+++ b/esmf_regrid/esmf_regridder.py
@@ -292,9 +292,7 @@ class Regridder:
         """
         src_inverted_mask = np.where(ma.getmaskarray(src_array), 0, 1)
         src_inverted_mask = self.src._flatten_array(src_inverted_mask)
-        src_mask_matrix = scipy.sparse.diags(src_inverted_mask)
-        masked_weights = self.weight_matrix * src_mask_matrix
-        weight_sums = np.array(masked_weights.sum(axis=1)).flatten()
+        weight_sums = self.weight_matrix * src_inverted_mask
         # Set the minimum mdtol to be slightly higher than 0 to account for rounding
         # errors.
         mdtol = max(mdtol, 1e-8)
@@ -310,8 +308,8 @@ class Regridder:
             raise ValueError(f'Normalisation type "{norm_type}" is not supported')
         normalisations = ma.array(normalisations, mask=np.logical_not(tgt_mask))
 
-        flat_src = self.src._flatten_array(ma.getdata(src_array))
-        flat_tgt = masked_weights * flat_src
+        flat_src = self.src._flatten_array(ma.getdata(src_array)) * src_inverted_mask
+        flat_tgt = self.weight_matrix * flat_src
         flat_tgt = flat_tgt * normalisations
         tgt_array = self.tgt._unflatten_array(flat_tgt)
         return tgt_array

--- a/esmf_regrid/tests/__init__.py
+++ b/esmf_regrid/tests/__init__.py
@@ -41,15 +41,15 @@ def get_result_path(relative_path, unit=True):
     return result.resolve(strict=True)
 
 
-def make_grid_args(x, y):
+def make_grid_args(nx, ny):
     """
     Return arguments for a small grid.
 
     Parameters
     ----------
-    x : int
+    nx : int
         The number of cells spanned by the longitude.
-    y : int
+    ny : int
         The number of cells spanned by the latutude
 
     Returns
@@ -58,11 +58,11 @@ def make_grid_args(x, y):
         Arguments which can be passed to
         :class:`~esmf_regrid.esmf_regridder.GridInfo.make_esmf_field`
     """
-    small_grid_lon = np.array(range(x)) * 10 / x
-    small_grid_lat = np.array(range(y)) * 10 / y
+    small_grid_lon = np.array(range(nx)) * 10 / nx
+    small_grid_lat = np.array(range(ny)) * 10 / ny
 
-    small_grid_lon_bounds = np.array(range(x + 1)) * 10 / x
-    small_grid_lat_bounds = np.array(range(y + 1)) * 10 / y
+    small_grid_lon_bounds = np.array(range(nx + 1)) * 10 / nx
+    small_grid_lat_bounds = np.array(range(ny + 1)) * 10 / ny
     return (
         small_grid_lon,
         small_grid_lat,

--- a/esmf_regrid/tests/__init__.py
+++ b/esmf_regrid/tests/__init__.py
@@ -44,7 +44,7 @@ def get_result_path(relative_path, unit=True):
 def make_grid_args(x, y):
     """
     Return arguments for a small grid.
-    
+
     Parameters
     ----------
     x : int

--- a/esmf_regrid/tests/__init__.py
+++ b/esmf_regrid/tests/__init__.py
@@ -1,6 +1,7 @@
 """Common testing infrastructure."""
 
 import pathlib
+
 import numpy as np
 
 
@@ -41,6 +42,21 @@ def get_result_path(relative_path, unit=True):
 
 
 def make_grid_args(x, y):
+    """
+    Return arguments for a small grid
+    Parameters
+    ----------
+    x : int
+        The number of cells spanned by the longitude.
+    y : int
+        The number of cells spanned by the latutude
+
+    Returns
+    -------
+    Tuple
+        Arguments which can be passed to
+        :class:`~esmf_regrid.esmf_regridder.GridInfo.make_esmf_field`
+    """
     small_grid_lon = np.array(range(x)) * 10 / x
     small_grid_lat = np.array(range(y)) * 10 / y
 

--- a/esmf_regrid/tests/__init__.py
+++ b/esmf_regrid/tests/__init__.py
@@ -1,6 +1,7 @@
 """Common testing infrastructure."""
 
 import pathlib
+import numpy as np
 
 
 # Base directory of the test results.
@@ -37,3 +38,17 @@ def get_result_path(relative_path, unit=True):
     result = _RESULT_PATH / relative_path
 
     return result.resolve(strict=True)
+
+
+def make_grid_args(x, y):
+    small_grid_lon = np.array(range(x)) * 10 / x
+    small_grid_lat = np.array(range(y)) * 10 / y
+
+    small_grid_lon_bounds = np.array(range(x + 1)) * 10 / x
+    small_grid_lat_bounds = np.array(range(y + 1)) * 10 / y
+    return (
+        small_grid_lon,
+        small_grid_lat,
+        small_grid_lon_bounds,
+        small_grid_lat_bounds,
+    )

--- a/esmf_regrid/tests/__init__.py
+++ b/esmf_regrid/tests/__init__.py
@@ -43,7 +43,8 @@ def get_result_path(relative_path, unit=True):
 
 def make_grid_args(x, y):
     """
-    Return arguments for a small grid
+    Return arguments for a small grid.
+    
     Parameters
     ----------
     x : int

--- a/esmf_regrid/tests/integration/__init__.py
+++ b/esmf_regrid/tests/integration/__init__.py
@@ -1,0 +1,1 @@
+"""Integration tests for esmf_regrid."""

--- a/esmf_regrid/tests/integration/esmf_regridder/__init__.py
+++ b/esmf_regrid/tests/integration/esmf_regridder/__init__.py
@@ -1,1 +1,1 @@
-"""Integration tests for esmf_regrid.esmf_regridder"""
+"""Integration tests for :mod:`esmf_regrid.esmf_regridder`."""

--- a/esmf_regrid/tests/integration/esmf_regridder/__init__.py
+++ b/esmf_regrid/tests/integration/esmf_regridder/__init__.py
@@ -1,0 +1,1 @@
+"""Integration tests for esmf_regrid.esmf_regridder"""

--- a/esmf_regrid/tests/integration/esmf_regridder/test_Regridder.py
+++ b/esmf_regrid/tests/integration/esmf_regridder/test_Regridder.py
@@ -1,0 +1,73 @@
+"""Unit tests for :class:`esmf_regrid.esmf_regridder.Regridder`."""
+
+import ESMF
+import numpy as np
+from numpy import ma
+
+from esmf_regrid.esmf_regridder import GridInfo, Regridder
+from esmf_regrid.tests import make_grid_args
+
+
+def test_esmpy_normalisation():
+    """
+    Itegration test for :meth:`~esmf_regrid.esmf_regridder.Regridder`.
+    Checks against ESMF.
+    """
+    src_data = np.array(
+        [
+            [1, 1, 1],
+            [1, 0, 0],
+        ],
+    )
+    src_mask = np.array(
+        [
+            [1, 0, 0],
+            [0, 0, 0],
+        ]
+    )
+    src_array = ma.array(src_data, mask=src_mask)
+
+    lon, lat, lon_bounds, lat_bounds = make_grid_args(2, 3)
+    src_grid = GridInfo(lon, lat, lon_bounds, lat_bounds)
+    src_esmpy_grid = src_grid._make_esmf_grid()
+    src_esmpy_grid.add_item(ESMF.GridItem.MASK, staggerloc=ESMF.StaggerLoc.CENTER)
+    src_esmpy_grid.mask[0][...] = src_mask.T
+    src_field = ESMF.Field(src_esmpy_grid)
+    src_field.data[...] = src_data.T
+
+    lon, lat, lon_bounds, lat_bounds = make_grid_args(3, 2)
+    tgt_grid = GridInfo(lon, lat, lon_bounds, lat_bounds)
+    tgt_field = tgt_grid.make_esmf_field()
+
+    regridder = Regridder(src_grid, tgt_grid)
+
+    esmpy_fracarea_regridder = ESMF.Regrid(
+        src_field,
+        tgt_field,
+        ignore_degenerate=True,
+        regrid_method=ESMF.RegridMethod.CONSERVE,
+        unmapped_action=ESMF.UnmappedAction.IGNORE,
+        norm_type=ESMF.NormType.FRACAREA,
+        factors=True,
+        src_mask_values=[1],
+    )
+    esmpy_dstarea_regridder = ESMF.Regrid(
+        src_field,
+        tgt_field,
+        ignore_degenerate=True,
+        regrid_method=ESMF.RegridMethod.CONSERVE,
+        unmapped_action=ESMF.UnmappedAction.IGNORE,
+        norm_type=ESMF.NormType.DSTAREA,
+        factors=True,
+        src_mask_values=[1],
+    )
+
+    tgt_field_dstarea = esmpy_dstarea_regridder(src_field, tgt_field)
+    result_esmpy_dstarea = tgt_field_dstarea.data
+    result_dstarea = regridder.regrid(src_array, norm_type="DSTAREA").T
+    assert ma.allclose(result_esmpy_dstarea, result_dstarea)
+
+    tgt_field_fracarea = esmpy_fracarea_regridder(src_field, tgt_field)
+    result_esmpy_fracarea = tgt_field_fracarea.data
+    result_fracarea = regridder.regrid(src_array, norm_type="FRACAREA").T
+    assert ma.allclose(result_esmpy_fracarea, result_fracarea)

--- a/esmf_regrid/tests/integration/esmf_regridder/test_Regridder.py
+++ b/esmf_regrid/tests/integration/esmf_regridder/test_Regridder.py
@@ -22,8 +22,8 @@ def test_esmpy_normalisation():
     )
     src_mask = np.array(
         [
-            [1, 0, 0],
-            [0, 0, 0],
+            [True, False, False],
+            [False, False, False],
         ]
     )
     src_array = ma.array(src_data, mask=src_mask)

--- a/esmf_regrid/tests/integration/esmf_regridder/test_Regridder.py
+++ b/esmf_regrid/tests/integration/esmf_regridder/test_Regridder.py
@@ -11,7 +11,8 @@ from esmf_regrid.tests import make_grid_args
 def test_esmpy_normalisation():
     """
     Itegration test for :meth:`~esmf_regrid.esmf_regridder.Regridder`.
-    Checks against ESMF.
+
+    Checks against ESMF to ensure results are consistent.
     """
     src_data = np.array(
         [

--- a/esmf_regrid/tests/integration/esmf_regridder/test_Regridder.py
+++ b/esmf_regrid/tests/integration/esmf_regridder/test_Regridder.py
@@ -10,14 +10,14 @@ from esmf_regrid.tests import make_grid_args
 
 def test_esmpy_normalisation():
     """
-    Itegration test for :meth:`~esmf_regrid.esmf_regridder.Regridder`.
+    Integration test for :meth:`~esmf_regrid.esmf_regridder.Regridder`.
 
     Checks against ESMF to ensure results are consistent.
     """
     src_data = np.array(
         [
-            [1, 1, 1],
-            [1, 0, 0],
+            [1.0, 1.0, 1.0],
+            [1.0, 0.0, 0.0],
         ],
     )
     src_mask = np.array(
@@ -42,33 +42,26 @@ def test_esmpy_normalisation():
 
     regridder = Regridder(src_grid, tgt_grid)
 
+    regridding_kwargs = {
+        "ignore_degenerate": True,
+        "regrid_method": ESMF.RegridMethod.CONSERVE,
+        "unmapped_action": ESMF.UnmappedAction.IGNORE,
+        "factors": True,
+        "src_mask_values": [1],
+    }
     esmpy_fracarea_regridder = ESMF.Regrid(
-        src_field,
-        tgt_field,
-        ignore_degenerate=True,
-        regrid_method=ESMF.RegridMethod.CONSERVE,
-        unmapped_action=ESMF.UnmappedAction.IGNORE,
-        norm_type=ESMF.NormType.FRACAREA,
-        factors=True,
-        src_mask_values=[1],
+        src_field, tgt_field, norm_type=ESMF.NormType.FRACAREA, **regridding_kwargs
     )
     esmpy_dstarea_regridder = ESMF.Regrid(
-        src_field,
-        tgt_field,
-        ignore_degenerate=True,
-        regrid_method=ESMF.RegridMethod.CONSERVE,
-        unmapped_action=ESMF.UnmappedAction.IGNORE,
-        norm_type=ESMF.NormType.DSTAREA,
-        factors=True,
-        src_mask_values=[1],
+        src_field, tgt_field, norm_type=ESMF.NormType.DSTAREA, **regridding_kwargs
     )
 
     tgt_field_dstarea = esmpy_dstarea_regridder(src_field, tgt_field)
     result_esmpy_dstarea = tgt_field_dstarea.data
-    result_dstarea = regridder.regrid(src_array, norm_type="DSTAREA").T
+    result_dstarea = regridder.regrid(src_array, norm_type="dstarea").T
     assert ma.allclose(result_esmpy_dstarea, result_dstarea)
 
     tgt_field_fracarea = esmpy_fracarea_regridder(src_field, tgt_field)
     result_esmpy_fracarea = tgt_field_fracarea.data
-    result_fracarea = regridder.regrid(src_array, norm_type="FRACAREA").T
+    result_fracarea = regridder.regrid(src_array, norm_type="fracarea").T
     assert ma.allclose(result_esmpy_fracarea, result_fracarea)

--- a/esmf_regrid/tests/unit/esmf_regridder/__init__.py
+++ b/esmf_regrid/tests/unit/esmf_regridder/__init__.py
@@ -1,0 +1,1 @@
+"""Unit tests for esmf_regrid.esmf_regridder"""

--- a/esmf_regrid/tests/unit/esmf_regridder/__init__.py
+++ b/esmf_regrid/tests/unit/esmf_regridder/__init__.py
@@ -1,1 +1,1 @@
-"""Unit tests for esmf_regrid.esmf_regridder"""
+"""Unit tests for :mod:`esmf_regrid.esmf_regridder`."""

--- a/esmf_regrid/tests/unit/esmf_regridder/test_Regridder.py
+++ b/esmf_regrid/tests/unit/esmf_regridder/test_Regridder.py
@@ -1,0 +1,67 @@
+"""Unit tests for :class:`esmf_regrid.esmf_regridder.Regridder`."""
+
+import numpy as np
+
+from esmf_regrid.esmf_regridder import GridInfo, Regridder
+import esmf_regrid.tests as tests
+from numpy import ma
+import scipy.sparse
+
+
+def make_small_grid_args(x, y):
+    small_grid_lon = np.array(range(x)) * 10 / x
+    small_grid_lat = np.array(range(y)) * 10 / y
+
+    small_grid_lon_bounds = np.array(range(x + 1)) * 10 / x
+    small_grid_lat_bounds = np.array(range(y + 1)) * 10 / y
+    return (
+        small_grid_lon,
+        small_grid_lat,
+        small_grid_lon_bounds,
+        small_grid_lat_bounds,
+    )
+
+
+def expected_weights():
+    weight_list = np.array(
+        [
+            0.6674194025656819,
+            0.3325805974343169,
+            0.3351257294386341,
+            0.6648742705613656,
+            0.33363933739884066,
+            0.1663606626011589,
+            0.333639337398841,
+            0.1663606626011591,
+            0.16742273275056854,
+            0.33250863479149745,
+            0.16742273275056876,
+            0.33250863479149767,
+            0.6674194025656823,
+            0.3325805974343174,
+            0.3351257294386344,
+            0.6648742705613663,
+        ]
+    )
+    rows = np.array([0, 0, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3, 4, 4, 5, 5])
+    columns = np.array([0, 1, 1, 2, 0, 1, 3, 4, 1, 2, 4, 5, 3, 4, 4, 5])
+
+    shape = (6, 6)
+
+    weights = scipy.sparse.csr_matrix((weight_list, (rows, columns)), shape=shape)
+    return weights
+
+
+def test_Regridder_init():
+    lon, lat, lon_bounds, lat_bounds = make_small_grid_args(2, 3)
+    src_grid = GridInfo(lon, lat, lon_bounds, lat_bounds)
+
+    lon, lat, lon_bounds, lat_bounds = make_small_grid_args(3, 2)
+    tgt_grid = GridInfo(lon, lat, lon_bounds, lat_bounds)
+
+    rg = Regridder(src_grid, tgt_grid)
+
+    result = rg.weight_matrix
+    expected = expected_weights()
+
+    assert np.allclose(result.toarray(), expected.toarray())

--- a/esmf_regrid/tests/unit/esmf_regridder/test_Regridder.py
+++ b/esmf_regrid/tests/unit/esmf_regridder/test_Regridder.py
@@ -2,6 +2,7 @@
 
 import numpy as np
 from numpy import ma
+import pytest
 import scipy.sparse
 
 from esmf_regrid.esmf_regridder import GridInfo, Regridder
@@ -114,3 +115,6 @@ def test_Regridder_regrid():
         ]
     )
     assert ma.allclose(result_dstarea, expected_dstarea)
+
+    with pytest.raises(ValueError):
+        _ = rg.regrid(src_masked, norm_type="INVALID")

--- a/esmf_regrid/tests/unit/esmf_regridder/test_Regridder.py
+++ b/esmf_regrid/tests/unit/esmf_regridder/test_Regridder.py
@@ -7,19 +7,6 @@ import scipy.sparse
 from esmf_regrid.esmf_regridder import GridInfo, Regridder
 from esmf_regrid.tests import make_grid_args
 
-# def _make_grid_args(x, y):
-#     small_grid_lon = np.array(range(x)) * 10 / x
-#     small_grid_lat = np.array(range(y)) * 10 / y
-#
-#     small_grid_lon_bounds = np.array(range(x + 1)) * 10 / x
-#     small_grid_lat_bounds = np.array(range(y + 1)) * 10 / y
-#     return (
-#         small_grid_lon,
-#         small_grid_lat,
-#         small_grid_lon_bounds,
-#         small_grid_lat_bounds,
-#     )
-
 
 def _expected_weights():
     weight_list = np.array(

--- a/esmf_regrid/tests/unit/esmf_regridder/test_Regridder.py
+++ b/esmf_regrid/tests/unit/esmf_regridder/test_Regridder.py
@@ -8,7 +8,7 @@ from numpy import ma
 import scipy.sparse
 
 
-def make_small_grid_args(x, y):
+def _make_small_grid_args(x, y):
     small_grid_lon = np.array(range(x)) * 10 / x
     small_grid_lat = np.array(range(y)) * 10 / y
 
@@ -22,7 +22,7 @@ def make_small_grid_args(x, y):
     )
 
 
-def expected_weights():
+def _expected_weights():
     weight_list = np.array(
         [
             0.6674194025656819,
@@ -53,15 +53,78 @@ def expected_weights():
 
 
 def test_Regridder_init():
-    lon, lat, lon_bounds, lat_bounds = make_small_grid_args(2, 3)
+    """Basic test for :meth:`~esmf_regrid.esmf_regridder.Regridder.__init__`."""
+    lon, lat, lon_bounds, lat_bounds = _make_small_grid_args(2, 3)
     src_grid = GridInfo(lon, lat, lon_bounds, lat_bounds)
 
-    lon, lat, lon_bounds, lat_bounds = make_small_grid_args(3, 2)
+    lon, lat, lon_bounds, lat_bounds = _make_small_grid_args(3, 2)
     tgt_grid = GridInfo(lon, lat, lon_bounds, lat_bounds)
 
     rg = Regridder(src_grid, tgt_grid)
 
     result = rg.weight_matrix
-    expected = expected_weights()
+    expected = _expected_weights()
 
     assert np.allclose(result.toarray(), expected.toarray())
+
+
+def test_Regridder_regrid():
+    """Basic test for :meth:`~esmf_regrid.esmf_regridder.Regridder.regrid`."""
+    lon, lat, lon_bounds, lat_bounds = _make_small_grid_args(2, 3)
+    src_grid = GridInfo(lon, lat, lon_bounds, lat_bounds)
+
+    lon, lat, lon_bounds, lat_bounds = _make_small_grid_args(3, 2)
+    tgt_grid = GridInfo(lon, lat, lon_bounds, lat_bounds)
+
+    # Set up the regridder with precomputed weights.
+    rg = Regridder(src_grid, tgt_grid, precomputed_weights=_expected_weights())
+
+    src_array = np.array([[1, 1, 1], [1, 0, 0]])
+    src_masked = ma.array(src_array, mask=[[1, 0, 0], [0, 0, 0]])
+
+    # Regrid with unmasked data.
+    result_nomask = rg.regrid(src_array)
+    expected_nomask = ma.array(
+        [
+            [1.0, 1.0],
+            [0.8336393373988409, 0.4999999999999997],
+            [0.6674194025656824, 0.0],
+        ]
+    )
+    assert ma.allclose(result_nomask, expected_nomask)
+
+    # Regrid with an masked array with no masked points.
+    result_ma_nomask = rg.regrid(ma.array(src_array))
+    assert ma.allclose(result_ma_nomask, expected_nomask)
+
+    # Regrid with a fully masked array.
+    result_fullmask = rg.regrid(ma.array(src_array, mask=True))
+    expected_fulmask = ma.array(np.zeros([3, 2]), mask=True)
+    assert ma.allclose(result_fullmask, expected_fulmask)
+
+    # Regrid with a masked array containing a masked point.
+    result_withmask = rg.regrid(src_masked)
+    expected_withmask = ma.array(
+        [
+            [0.9999999999999999, 1.0],
+            [0.7503444126612077, 0.4999999999999997],
+            [0.6674194025656824, 0.0],
+        ]
+    )
+    assert ma.allclose(result_withmask, expected_withmask)
+
+    # Regrid while setting mdtol.
+    result_half_mdtol = rg.regrid(src_masked, mdtol=0.5)
+    expected_half_mdtol = ma.array(expected_withmask, mask=[[1, 0], [0, 0], [1, 0]])
+    assert ma.allclose(result_half_mdtol, expected_half_mdtol)
+
+    # Regrid with norm_type="DSTAREA".
+    result_dstarea = rg.regrid(src_masked, norm_type="DSTAREA")
+    expected_dstarea = ma.array(
+        [
+            [0.3325805974343169, 0.9999999999999998],
+            [0.4999999999999999, 0.499931367542066],
+            [0.6674194025656823, 0.0],
+        ]
+    )
+    assert ma.allclose(result_dstarea, expected_dstarea)

--- a/esmf_regrid/tests/unit/esmf_regridder/test_Regridder.py
+++ b/esmf_regrid/tests/unit/esmf_regridder/test_Regridder.py
@@ -127,6 +127,3 @@ def test_Regridder_regrid():
         ]
     )
     assert ma.allclose(result_dstarea, expected_dstarea)
-
-
-test_Regridder_init()

--- a/esmf_regrid/tests/unit/esmf_regridder/test_Regridder.py
+++ b/esmf_regrid/tests/unit/esmf_regridder/test_Regridder.py
@@ -65,7 +65,7 @@ def test_Regridder_regrid():
     # Set up the regridder with precomputed weights.
     rg = Regridder(src_grid, tgt_grid, precomputed_weights=_expected_weights())
 
-    src_array = np.array([[1, 1, 1], [1, 0, 0]])
+    src_array = np.array([[1.0, 1.0, 1.0], [1.0, 0.0, 0.0]])
     src_masked = ma.array(src_array, mask=[[1, 0, 0], [0, 0, 0]])
 
     # Regrid with unmasked data.
@@ -104,8 +104,8 @@ def test_Regridder_regrid():
     expected_half_mdtol = ma.array(expected_withmask, mask=[[1, 0], [0, 0], [1, 0]])
     assert ma.allclose(result_half_mdtol, expected_half_mdtol)
 
-    # Regrid with norm_type="DSTAREA".
-    result_dstarea = rg.regrid(src_masked, norm_type="DSTAREA")
+    # Regrid with norm_type="dstarea".
+    result_dstarea = rg.regrid(src_masked, norm_type="dstarea")
     expected_dstarea = ma.array(
         [
             [0.3325805974343169, 0.9999999999999998],

--- a/esmf_regrid/tests/unit/esmf_regridder/test_Regridder.py
+++ b/esmf_regrid/tests/unit/esmf_regridder/test_Regridder.py
@@ -5,20 +5,20 @@ from numpy import ma
 import scipy.sparse
 
 from esmf_regrid.esmf_regridder import GridInfo, Regridder
+from esmf_regrid.tests import make_grid_args
 
-
-def _make_small_grid_args(x, y):
-    small_grid_lon = np.array(range(x)) * 10 / x
-    small_grid_lat = np.array(range(y)) * 10 / y
-
-    small_grid_lon_bounds = np.array(range(x + 1)) * 10 / x
-    small_grid_lat_bounds = np.array(range(y + 1)) * 10 / y
-    return (
-        small_grid_lon,
-        small_grid_lat,
-        small_grid_lon_bounds,
-        small_grid_lat_bounds,
-    )
+# def _make_grid_args(x, y):
+#     small_grid_lon = np.array(range(x)) * 10 / x
+#     small_grid_lat = np.array(range(y)) * 10 / y
+#
+#     small_grid_lon_bounds = np.array(range(x + 1)) * 10 / x
+#     small_grid_lat_bounds = np.array(range(y + 1)) * 10 / y
+#     return (
+#         small_grid_lon,
+#         small_grid_lat,
+#         small_grid_lon_bounds,
+#         small_grid_lat_bounds,
+#     )
 
 
 def _expected_weights():
@@ -53,10 +53,10 @@ def _expected_weights():
 
 def test_Regridder_init():
     """Basic test for :meth:`~esmf_regrid.esmf_regridder.Regridder.__init__`."""
-    lon, lat, lon_bounds, lat_bounds = _make_small_grid_args(2, 3)
+    lon, lat, lon_bounds, lat_bounds = make_grid_args(2, 3)
     src_grid = GridInfo(lon, lat, lon_bounds, lat_bounds)
 
-    lon, lat, lon_bounds, lat_bounds = _make_small_grid_args(3, 2)
+    lon, lat, lon_bounds, lat_bounds = make_grid_args(3, 2)
     tgt_grid = GridInfo(lon, lat, lon_bounds, lat_bounds)
 
     rg = Regridder(src_grid, tgt_grid)
@@ -69,10 +69,10 @@ def test_Regridder_init():
 
 def test_Regridder_regrid():
     """Basic test for :meth:`~esmf_regrid.esmf_regridder.Regridder.regrid`."""
-    lon, lat, lon_bounds, lat_bounds = _make_small_grid_args(2, 3)
+    lon, lat, lon_bounds, lat_bounds = make_grid_args(2, 3)
     src_grid = GridInfo(lon, lat, lon_bounds, lat_bounds)
 
-    lon, lat, lon_bounds, lat_bounds = _make_small_grid_args(3, 2)
+    lon, lat, lon_bounds, lat_bounds = make_grid_args(3, 2)
     tgt_grid = GridInfo(lon, lat, lon_bounds, lat_bounds)
 
     # Set up the regridder with precomputed weights.
@@ -127,3 +127,6 @@ def test_Regridder_regrid():
         ]
     )
     assert ma.allclose(result_dstarea, expected_dstarea)
+
+
+test_Regridder_init()

--- a/esmf_regrid/tests/unit/esmf_regridder/test_Regridder.py
+++ b/esmf_regrid/tests/unit/esmf_regridder/test_Regridder.py
@@ -1,11 +1,10 @@
 """Unit tests for :class:`esmf_regrid.esmf_regridder.Regridder`."""
 
 import numpy as np
-
-from esmf_regrid.esmf_regridder import GridInfo, Regridder
-import esmf_regrid.tests as tests
 from numpy import ma
 import scipy.sparse
+
+from esmf_regrid.esmf_regridder import GridInfo, Regridder
 
 
 def _make_small_grid_args(x, y):


### PR DESCRIPTION
This addresses #20. It allows the regridding of masked arrays. It also supports a choice of normalisation options (as described [here](http://earthsystemmodeling.org/esmf_releases/public/ESMF_8_0_1/esmpy_doc/html/NormType.html)). This PR also improves the test coverage for the regridder which was missing in the initial code.