### PR TITLE
Sparse array approach

### DIFF
--- a/esmf_regrid/esmf_regridder.py
+++ b/esmf_regrid/esmf_regridder.py
@@ -31,7 +31,14 @@ class GridInfo:
     # TODO: Edit GridInfo so that it is able to handle 2D lat/lon arrays.
 
     def __init__(
-        self, lons, lats, lonbounds, latbounds, crs=None, circular=False, areas=None,
+        self,
+        lons,
+        lats,
+        lonbounds,
+        latbounds,
+        crs=None,
+        circular=False,
+        areas=None,
     ):
         """
         Create a GridInfo object describing the grid.
@@ -120,7 +127,11 @@ class GridInfo:
 
         if circular:
             grid = ESMF.Grid(
-                shape, pole_kind=[1, 1], num_peri_dims=1, periodic_dim=1, pole_dim=0,
+                shape,
+                pole_kind=[1, 1],
+                num_peri_dims=1,
+                periodic_dim=1,
+                pole_dim=0,
             )
         else:
             grid = ESMF.Grid(shape, pole_kind=[1, 1])
@@ -249,7 +260,8 @@ class Regridder:
                 msg = "Expected precomputed weights to have shape {}, got shape {} instead."
                 raise ValueError(
                     msg.format(
-                        (self.tgt.size(), self.src.size()), precomputed_weights.shape,
+                        (self.tgt.size(), self.src.size()),
+                        precomputed_weights.shape,
                     )
                 )
             self.weight_matrix = precomputed_weights

--- a/esmf_regrid/esmf_regridder.py
+++ b/esmf_regrid/esmf_regridder.py
@@ -4,7 +4,7 @@ import cartopy.crs as ccrs
 import ESMF
 import numpy as np
 from numpy import ma
-import scipy.sparse
+import sparse
 
 
 __all__ = [
@@ -169,17 +169,15 @@ class GridInfo:
         """TBD: public method docstring."""
         return len(self.lons) * len(self.lats)
 
+    @property
+    def shape(self):
+        return self.lats.shape + self.lons.shape
+
     def _index_offset(self):
         return 1
 
-    def _flatten_array(self, array):
-        return array.flatten()
 
-    def _unflatten_array(self, array):
-        return array.reshape((len(self.lons), len(self.lats)))
-
-
-def _get_regrid_weights_dict(src_field, tgt_field):
+def _get_regrid_weights(src_field, tgt_field):
     regridder = ESMF.Regrid(
         src_field,
         tgt_field,
@@ -191,27 +189,13 @@ def _get_regrid_weights_dict(src_field, tgt_field):
         norm_type=ESMF.NormType.DSTAREA,
         factors=True,
     )
-    # Without specifying deep_copy=true, the information in weights_dict
+    # Without specifying deep_copy=true, the information in weights
     # would be corrupted when the ESMF regridder is destoyed.
-    weights_dict = regridder.get_weights_dict(deep_copy=True)
-    # The weights_dict contains all the information needed for regridding,
+    weights = regridder.get_factors(deep_copy=True)
+    # The weights contains all the information needed for regridding,
     # the ESMF objects can be safely removed.
     regridder.destroy()
-    return weights_dict
-
-
-def _weights_dict_to_sparse_array(weights, shape, index_offsets):
-    matrix = scipy.sparse.csr_matrix(
-        (
-            weights["weights"],
-            (
-                weights["row_dst"] - index_offsets[0],
-                weights["col_src"] - index_offsets[1],
-            ),
-        ),
-        shape=shape,
-    )
-    return matrix
+    return weights
 
 
 class Regridder:
@@ -243,28 +227,26 @@ class Regridder:
         self.tgt = tgt
 
         if precomputed_weights is None:
-            weights_dict = _get_regrid_weights_dict(
-                src.make_esmf_field(), tgt.make_esmf_field()
-            )
-            self.weight_matrix = _weights_dict_to_sparse_array(
-                weights_dict,
-                (self.tgt.size(), self.src.size()),
-                (self.tgt._index_offset(), self.src._index_offset()),
-            )
+            src_field = src.make_esmf_field()
+            tgt_field = tgt.make_esmf_field()
+            factors, factors_index = _get_regrid_weights(src_field, tgt_field)
+            src_shape = tuple(i - 1 for i in reversed(src_field.grid.size[ESMF.StaggerLoc.CORNER]))
+            tgt_shape = tuple(i - 1 for i in reversed(tgt_field.grid.size[ESMF.StaggerLoc.CORNER]))
+            tensor_shape = src_shape + tgt_shape
+            src_inds = np.unravel_index(factors_index[:, 0]-1, src_shape)
+            tgt_inds = np.unravel_index(factors_index[:, 1]-1, tgt_shape)
+            inds = np.vstack(src_inds + tgt_inds)
+            self.weights = sparse.COO(inds, factors.astype('d'), shape=tensor_shape)
         else:
-            if not scipy.sparse.isspmatrix(precomputed_weights):
-                raise ValueError(
-                    "Precomputed weights must be given as a sparse matrix."
-                )
-            if precomputed_weights.shape != (self.tgt.size(), self.src.size()):
+            if precomputed_weights.shape != self.tgt.shape + self.src.shape:
                 msg = "Expected precomputed weights to have shape {}, got shape {} instead."
                 raise ValueError(
                     msg.format(
-                        (self.tgt.size(), self.src.size()),
+                        self.tgt.shape + self.src.shape,
                         precomputed_weights.shape,
                     )
                 )
-            self.weight_matrix = precomputed_weights
+            self.weights = precomputed_weights
 
     def regrid(self, src_array, norm_type="FRACAREA", mdtol=1):
         """
@@ -290,26 +272,20 @@ class Regridder:
             A numpy array whose shape is compatible with self.tgt.
 
         """
-        src_inverted_mask = np.where(ma.getmaskarray(src_array), 0, 1)
-        src_inverted_mask = self.src._flatten_array(src_inverted_mask)
-        weight_sums = self.weight_matrix * src_inverted_mask
+        filled_src = ma.filled(src_array, 0.)
+        tgt_array = np.tensordot(filled_src, self.weights)
+
+        weight_sums = np.tensordot(~ma.getmaskarray(src_array), self.weights)
         # Set the minimum mdtol to be slightly higher than 0 to account for rounding
         # errors.
         mdtol = max(mdtol, 1e-8)
-        tgt_mask = weight_sums > 1 - mdtol
-        masked_weight_sums = weight_sums * tgt_mask.astype(int)
+        tgt_mask = weight_sums > 1. - mdtol
         if norm_type == "FRACAREA":
-            normalisations = np.where(
-                masked_weight_sums == 0, 0, 1 / masked_weight_sums
-            )
+            tgt_array[tgt_mask] /= weight_sums[tgt_mask]
         elif norm_type == "DSTAREA":
-            normalisations = np.ones(self.tgt.size())
+            pass
         else:
             raise ValueError(f'Normalisation type "{norm_type}" is not supported')
-        normalisations = ma.array(normalisations, mask=np.logical_not(tgt_mask))
 
-        flat_src = self.src._flatten_array(ma.getdata(src_array)) * src_inverted_mask
-        flat_tgt = self.weight_matrix * flat_src
-        flat_tgt = flat_tgt * normalisations
-        tgt_array = self.tgt._unflatten_array(flat_tgt)
-        return tgt_array
+        result = ma.masked_array(tgt_array, tgt_mask)
+        return result

--- a/esmf_regrid/esmf_regridder.py
+++ b/esmf_regrid/esmf_regridder.py
@@ -31,14 +31,7 @@ class GridInfo:
     # TODO: Edit GridInfo so that it is able to handle 2D lat/lon arrays.
 
     def __init__(
-        self,
-        lons,
-        lats,
-        lonbounds,
-        latbounds,
-        crs=None,
-        circular=False,
-        areas=None,
+        self, lons, lats, lonbounds, latbounds, crs=None, circular=False, areas=None,
     ):
         """
         Create a GridInfo object describing the grid.
@@ -127,11 +120,7 @@ class GridInfo:
 
         if circular:
             grid = ESMF.Grid(
-                shape,
-                pole_kind=[1, 1],
-                num_peri_dims=1,
-                periodic_dim=1,
-                pole_dim=0,
+                shape, pole_kind=[1, 1], num_peri_dims=1, periodic_dim=1, pole_dim=0,
             )
         else:
             grid = ESMF.Grid(shape, pole_kind=[1, 1])
@@ -260,8 +249,7 @@ class Regridder:
                 msg = "Expected precomputed weights to have shape {}, got shape {} instead."
                 raise ValueError(
                     msg.format(
-                        (self.tgt.size(), self.src.size()),
-                        precomputed_weights.shape,
+                        (self.tgt.size(), self.src.size()), precomputed_weights.shape,
                     )
                 )
             self.weight_matrix = precomputed_weights
@@ -301,11 +289,13 @@ class Regridder:
         tgt_mask = weight_sums > 1 - mdtol
         masked_weight_sums = weight_sums * tgt_mask.astype(int)
         if norm_type == "FRACAREA":
-            normalisations = np.where(masked_weight_sums == 0, 0, 1 / masked_weight_sums)
+            normalisations = np.where(
+                masked_weight_sums == 0, 0, 1 / masked_weight_sums
+            )
         elif norm_type == "DSTAREA":
             normalisations = np.ones(self.tgt.size())
         else:
-            raise ValueError(f"Normalisation type \"{norm_type}\" is not supported")
+            raise ValueError(f'Normalisation type "{norm_type}" is not supported')
         normalisations = ma.array(normalisations, mask=np.logical_not(tgt_mask))
 
         flat_src = self.src._flatten_array(ma.getdata(src_array))

--- a/esmf_regrid/esmf_regridder.py
+++ b/esmf_regrid/esmf_regridder.py
@@ -266,7 +266,7 @@ class Regridder:
                 )
             self.weight_matrix = precomputed_weights
 
-    def regrid(self, src_array, mdtol=1):
+    def regrid(self, src_array, norm_type="FRACAREA", mdtol=1):
         """
         Perform regridding on an array of data.
 
@@ -290,16 +290,8 @@ class Regridder:
             A numpy array whose shape is compatible with self.tgt.
 
         """
-        # A rudimentary filter is applied to mask data which is mapped from an
-        # insufficiently large source. This currently only accounts for discrepancies
-        # between the source and target grid/mesh geometries and does not account for
-        # masked data, though it ought to be possible to extend the functionality to
-        # handle masked data.
-        #
-        # Note that ESMPy is also able to handle masked data. It is worth investigating
-        # how this affects the mathematics and if it can be replicated after the fact
-        # using just the weights or if ESMF is doing something we want access to.
         src_inverted_mask = np.where(ma.getmaskarray(src_array), 0, 1)
+        src_inverted_mask = self.src._flatten_array(src_inverted_mask)
         src_mask_matrix = scipy.sparse.diags(src_inverted_mask)
         masked_weights = self.weight_matrix * src_mask_matrix
         weight_sums = np.array(masked_weights.sum(axis=1)).flatten()
@@ -308,11 +300,16 @@ class Regridder:
         mdtol = max(mdtol, 1e-8)
         tgt_mask = weight_sums >= 1 - mdtol
         masked_weight_sums = weight_sums * tgt_mask.astype(int)
-        normalisations = np.where(masked_weight_sums == 0, 0, 1 / masked_weight_sums)
+        if norm_type == "FRACAREA":
+            normalisations = np.where(masked_weight_sums == 0, 0, 1 / masked_weight_sums)
+        elif norm_type == "DSTAREA":
+            normalisations = np.ones(self.tgt.size())
+        else:
+            raise ValueError(f"Normalisation type \"{norm_type}\" is not supported")
         normalisations = ma.array(normalisations, mask=np.logical_not(tgt_mask))
 
         flat_src = self.src._flatten_array(ma.getdata(src_array))
-        flat_tgt = self.weight_matrix * flat_src
+        flat_tgt = masked_weights * flat_src
         flat_tgt = flat_tgt * normalisations
         tgt_array = self.tgt._unflatten_array(flat_tgt)
         return tgt_array

--- a/esmf_regrid/esmf_regridder.py
+++ b/esmf_regrid/esmf_regridder.py
@@ -298,7 +298,7 @@ class Regridder:
         # Set the minimum mdtol to be slightly higher than 0 to account for rounding
         # errors.
         mdtol = max(mdtol, 1e-8)
-        tgt_mask = weight_sums >= 1 - mdtol
+        tgt_mask = weight_sums > 1 - mdtol
         masked_weight_sums = weight_sums * tgt_mask.astype(int)
         if norm_type == "FRACAREA":
             normalisations = np.where(masked_weight_sums == 0, 0, 1 / masked_weight_sums)

--- a/esmf_regrid/esmf_regridder.py
+++ b/esmf_regrid/esmf_regridder.py
@@ -292,9 +292,7 @@ class Regridder:
         """
         src_inverted_mask = np.where(ma.getmaskarray(src_array), 0, 1)
         src_inverted_mask = self.src._flatten_array(src_inverted_mask)
-        src_mask_matrix = scipy.sparse.diags(src_inverted_mask)
-        masked_weights = self.weight_matrix * src_mask_matrix
-        weight_sums = np.array(masked_weights.sum(axis=1)).flatten()
+        weight_sums = self.weight_matrix * src_inverted_mask
         # Set the minimum mdtol to be slightly higher than 0 to account for rounding
         # errors.
         mdtol = max(mdtol, 1e-8)
@@ -310,8 +308,8 @@ class Regridder:
             raise ValueError(f'Normalisation type "{norm_type}" is not supported')
         normalisations = ma.array(normalisations, mask=np.logical_not(tgt_mask))
 
-        flat_src = self.src._flatten_array(ma.getdata(src_array))
-        flat_tgt = masked_weights * flat_src
+        flat_src = self.src._flatten_array(ma.getdata(src_array)) * src_inverted_mask
+        flat_tgt = self.weight_matrix * flat_src
         flat_tgt = flat_tgt * normalisations
         tgt_array = self.tgt._unflatten_array(flat_tgt)
         return tgt_array

--- a/esmf_regrid/tests/__init__.py
+++ b/esmf_regrid/tests/__init__.py
@@ -44,7 +44,7 @@ def get_result_path(relative_path, unit=True):
 def make_grid_args(x, y):
     """
     Return arguments for a small grid.
-    
+
     Parameters
     ----------
     x : int

--- a/esmf_regrid/tests/__init__.py
+++ b/esmf_regrid/tests/__init__.py
@@ -1,6 +1,7 @@
 """Common testing infrastructure."""
 
 import pathlib
+
 import numpy as np
 
 
@@ -41,6 +42,21 @@ def get_result_path(relative_path, unit=True):
 
 
 def make_grid_args(x, y):
+    """
+    Return arguments for a small grid
+    Parameters
+    ----------
+    x : int
+        The number of cells spanned by the longitude.
+    y : int
+        The number of cells spanned by the latutude
+
+    Returns
+    -------
+    Tuple
+        Arguments which can be passed to
+        :class:`~esmf_regrid.esmf_regridder.GridInfo.make_esmf_field`
+    """
     small_grid_lon = np.array(range(x)) * 10 / x
     small_grid_lat = np.array(range(y)) * 10 / y
 

--- a/esmf_regrid/tests/__init__.py
+++ b/esmf_regrid/tests/__init__.py
@@ -1,6 +1,7 @@
 """Common testing infrastructure."""
 
 import pathlib
+import numpy as np
 
 
 # Base directory of the test results.
@@ -37,3 +38,17 @@ def get_result_path(relative_path, unit=True):
     result = _RESULT_PATH / relative_path
 
     return result.resolve(strict=True)
+
+
+def make_grid_args(x, y):
+    small_grid_lon = np.array(range(x)) * 10 / x
+    small_grid_lat = np.array(range(y)) * 10 / y
+
+    small_grid_lon_bounds = np.array(range(x + 1)) * 10 / x
+    small_grid_lat_bounds = np.array(range(y + 1)) * 10 / y
+    return (
+        small_grid_lon,
+        small_grid_lat,
+        small_grid_lon_bounds,
+        small_grid_lat_bounds,
+    )

--- a/esmf_regrid/tests/__init__.py
+++ b/esmf_regrid/tests/__init__.py
@@ -43,7 +43,8 @@ def get_result_path(relative_path, unit=True):
 
 def make_grid_args(x, y):
     """
-    Return arguments for a small grid
+    Return arguments for a small grid.
+    
     Parameters
     ----------
     x : int

--- a/esmf_regrid/tests/integration/__init__.py
+++ b/esmf_regrid/tests/integration/__init__.py
@@ -1,0 +1,1 @@
+"""Integration tests for esmf_regrid."""

--- a/esmf_regrid/tests/integration/esmf_regridder/__init__.py
+++ b/esmf_regrid/tests/integration/esmf_regridder/__init__.py
@@ -1,1 +1,1 @@
-"""Integration tests for esmf_regrid.esmf_regridder"""
+"""Integration tests for :mod:`esmf_regrid.esmf_regridder`."""

--- a/esmf_regrid/tests/integration/esmf_regridder/__init__.py
+++ b/esmf_regrid/tests/integration/esmf_regridder/__init__.py
@@ -1,0 +1,1 @@
+"""Integration tests for esmf_regrid.esmf_regridder"""

--- a/esmf_regrid/tests/integration/esmf_regridder/test_Regridder.py
+++ b/esmf_regrid/tests/integration/esmf_regridder/test_Regridder.py
@@ -1,0 +1,73 @@
+"""Unit tests for :class:`esmf_regrid.esmf_regridder.Regridder`."""
+
+import ESMF
+import numpy as np
+from numpy import ma
+
+from esmf_regrid.esmf_regridder import GridInfo, Regridder
+from esmf_regrid.tests import make_grid_args
+
+
+def test_esmpy_normalisation():
+    """
+    Itegration test for :meth:`~esmf_regrid.esmf_regridder.Regridder`.
+    Checks against ESMF.
+    """
+    src_data = np.array(
+        [
+            [1, 1, 1],
+            [1, 0, 0],
+        ],
+    )
+    src_mask = np.array(
+        [
+            [1, 0, 0],
+            [0, 0, 0],
+        ]
+    )
+    src_array = ma.array(src_data, mask=src_mask)
+
+    lon, lat, lon_bounds, lat_bounds = make_grid_args(2, 3)
+    src_grid = GridInfo(lon, lat, lon_bounds, lat_bounds)
+    src_esmpy_grid = src_grid._make_esmf_grid()
+    src_esmpy_grid.add_item(ESMF.GridItem.MASK, staggerloc=ESMF.StaggerLoc.CENTER)
+    src_esmpy_grid.mask[0][...] = src_mask.T
+    src_field = ESMF.Field(src_esmpy_grid)
+    src_field.data[...] = src_data.T
+
+    lon, lat, lon_bounds, lat_bounds = make_grid_args(3, 2)
+    tgt_grid = GridInfo(lon, lat, lon_bounds, lat_bounds)
+    tgt_field = tgt_grid.make_esmf_field()
+
+    regridder = Regridder(src_grid, tgt_grid)
+
+    esmpy_fracarea_regridder = ESMF.Regrid(
+        src_field,
+        tgt_field,
+        ignore_degenerate=True,
+        regrid_method=ESMF.RegridMethod.CONSERVE,
+        unmapped_action=ESMF.UnmappedAction.IGNORE,
+        norm_type=ESMF.NormType.FRACAREA,
+        factors=True,
+        src_mask_values=[1],
+    )
+    esmpy_dstarea_regridder = ESMF.Regrid(
+        src_field,
+        tgt_field,
+        ignore_degenerate=True,
+        regrid_method=ESMF.RegridMethod.CONSERVE,
+        unmapped_action=ESMF.UnmappedAction.IGNORE,
+        norm_type=ESMF.NormType.DSTAREA,
+        factors=True,
+        src_mask_values=[1],
+    )
+
+    tgt_field_dstarea = esmpy_dstarea_regridder(src_field, tgt_field)
+    result_esmpy_dstarea = tgt_field_dstarea.data
+    result_dstarea = regridder.regrid(src_array, norm_type="DSTAREA").T
+    assert ma.allclose(result_esmpy_dstarea, result_dstarea)
+
+    tgt_field_fracarea = esmpy_fracarea_regridder(src_field, tgt_field)
+    result_esmpy_fracarea = tgt_field_fracarea.data
+    result_fracarea = regridder.regrid(src_array, norm_type="FRACAREA").T
+    assert ma.allclose(result_esmpy_fracarea, result_fracarea)

--- a/esmf_regrid/tests/integration/esmf_regridder/test_Regridder.py
+++ b/esmf_regrid/tests/integration/esmf_regridder/test_Regridder.py
@@ -11,7 +11,8 @@ from esmf_regrid.tests import make_grid_args
 def test_esmpy_normalisation():
     """
     Itegration test for :meth:`~esmf_regrid.esmf_regridder.Regridder`.
-    Checks against ESMF.
+
+    Checks against ESMF to ensure results are consistent.
     """
     src_data = np.array(
         [

--- a/esmf_regrid/tests/unit/esmf_regridder/__init__.py
+++ b/esmf_regrid/tests/unit/esmf_regridder/__init__.py
@@ -1,0 +1,1 @@
+"""Unit tests for esmf_regrid.esmf_regridder"""

--- a/esmf_regrid/tests/unit/esmf_regridder/__init__.py
+++ b/esmf_regrid/tests/unit/esmf_regridder/__init__.py
@@ -1,1 +1,1 @@
-"""Unit tests for esmf_regrid.esmf_regridder"""
+"""Unit tests for :mod:`esmf_regrid.esmf_regridder`."""

--- a/esmf_regrid/tests/unit/esmf_regridder/test_Regridder.py
+++ b/esmf_regrid/tests/unit/esmf_regridder/test_Regridder.py
@@ -1,0 +1,67 @@
+"""Unit tests for :class:`esmf_regrid.esmf_regridder.Regridder`."""
+
+import numpy as np
+
+from esmf_regrid.esmf_regridder import GridInfo, Regridder
+import esmf_regrid.tests as tests
+from numpy import ma
+import scipy.sparse
+
+
+def make_small_grid_args(x, y):
+    small_grid_lon = np.array(range(x)) * 10 / x
+    small_grid_lat = np.array(range(y)) * 10 / y
+
+    small_grid_lon_bounds = np.array(range(x + 1)) * 10 / x
+    small_grid_lat_bounds = np.array(range(y + 1)) * 10 / y
+    return (
+        small_grid_lon,
+        small_grid_lat,
+        small_grid_lon_bounds,
+        small_grid_lat_bounds,
+    )
+
+
+def expected_weights():
+    weight_list = np.array(
+        [
+            0.6674194025656819,
+            0.3325805974343169,
+            0.3351257294386341,
+            0.6648742705613656,
+            0.33363933739884066,
+            0.1663606626011589,
+            0.333639337398841,
+            0.1663606626011591,
+            0.16742273275056854,
+            0.33250863479149745,
+            0.16742273275056876,
+            0.33250863479149767,
+            0.6674194025656823,
+            0.3325805974343174,
+            0.3351257294386344,
+            0.6648742705613663,
+        ]
+    )
+    rows = np.array([0, 0, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3, 4, 4, 5, 5])
+    columns = np.array([0, 1, 1, 2, 0, 1, 3, 4, 1, 2, 4, 5, 3, 4, 4, 5])
+
+    shape = (6, 6)
+
+    weights = scipy.sparse.csr_matrix((weight_list, (rows, columns)), shape=shape)
+    return weights
+
+
+def test_Regridder_init():
+    lon, lat, lon_bounds, lat_bounds = make_small_grid_args(2, 3)
+    src_grid = GridInfo(lon, lat, lon_bounds, lat_bounds)
+
+    lon, lat, lon_bounds, lat_bounds = make_small_grid_args(3, 2)
+    tgt_grid = GridInfo(lon, lat, lon_bounds, lat_bounds)
+
+    rg = Regridder(src_grid, tgt_grid)
+
+    result = rg.weight_matrix
+    expected = expected_weights()
+
+    assert np.allclose(result.toarray(), expected.toarray())

--- a/esmf_regrid/tests/unit/esmf_regridder/test_Regridder.py
+++ b/esmf_regrid/tests/unit/esmf_regridder/test_Regridder.py
@@ -7,19 +7,6 @@ import scipy.sparse
 from esmf_regrid.esmf_regridder import GridInfo, Regridder
 from esmf_regrid.tests import make_grid_args
 
-# def _make_grid_args(x, y):
-#     small_grid_lon = np.array(range(x)) * 10 / x
-#     small_grid_lat = np.array(range(y)) * 10 / y
-#
-#     small_grid_lon_bounds = np.array(range(x + 1)) * 10 / x
-#     small_grid_lat_bounds = np.array(range(y + 1)) * 10 / y
-#     return (
-#         small_grid_lon,
-#         small_grid_lat,
-#         small_grid_lon_bounds,
-#         small_grid_lat_bounds,
-#     )
-
 
 def _expected_weights():
     weight_list = np.array(

--- a/esmf_regrid/tests/unit/esmf_regridder/test_Regridder.py
+++ b/esmf_regrid/tests/unit/esmf_regridder/test_Regridder.py
@@ -8,7 +8,7 @@ from numpy import ma
 import scipy.sparse
 
 
-def make_small_grid_args(x, y):
+def _make_small_grid_args(x, y):
     small_grid_lon = np.array(range(x)) * 10 / x
     small_grid_lat = np.array(range(y)) * 10 / y
 
@@ -22,7 +22,7 @@ def make_small_grid_args(x, y):
     )
 
 
-def expected_weights():
+def _expected_weights():
     weight_list = np.array(
         [
             0.6674194025656819,
@@ -53,15 +53,78 @@ def expected_weights():
 
 
 def test_Regridder_init():
-    lon, lat, lon_bounds, lat_bounds = make_small_grid_args(2, 3)
+    """Basic test for :meth:`~esmf_regrid.esmf_regridder.Regridder.__init__`."""
+    lon, lat, lon_bounds, lat_bounds = _make_small_grid_args(2, 3)
     src_grid = GridInfo(lon, lat, lon_bounds, lat_bounds)
 
-    lon, lat, lon_bounds, lat_bounds = make_small_grid_args(3, 2)
+    lon, lat, lon_bounds, lat_bounds = _make_small_grid_args(3, 2)
     tgt_grid = GridInfo(lon, lat, lon_bounds, lat_bounds)
 
     rg = Regridder(src_grid, tgt_grid)
 
     result = rg.weight_matrix
-    expected = expected_weights()
+    expected = _expected_weights()
 
     assert np.allclose(result.toarray(), expected.toarray())
+
+
+def test_Regridder_regrid():
+    """Basic test for :meth:`~esmf_regrid.esmf_regridder.Regridder.regrid`."""
+    lon, lat, lon_bounds, lat_bounds = _make_small_grid_args(2, 3)
+    src_grid = GridInfo(lon, lat, lon_bounds, lat_bounds)
+
+    lon, lat, lon_bounds, lat_bounds = _make_small_grid_args(3, 2)
+    tgt_grid = GridInfo(lon, lat, lon_bounds, lat_bounds)
+
+    # Set up the regridder with precomputed weights.
+    rg = Regridder(src_grid, tgt_grid, precomputed_weights=_expected_weights())
+
+    src_array = np.array([[1, 1, 1], [1, 0, 0]])
+    src_masked = ma.array(src_array, mask=[[1, 0, 0], [0, 0, 0]])
+
+    # Regrid with unmasked data.
+    result_nomask = rg.regrid(src_array)
+    expected_nomask = ma.array(
+        [
+            [1.0, 1.0],
+            [0.8336393373988409, 0.4999999999999997],
+            [0.6674194025656824, 0.0],
+        ]
+    )
+    assert ma.allclose(result_nomask, expected_nomask)
+
+    # Regrid with an masked array with no masked points.
+    result_ma_nomask = rg.regrid(ma.array(src_array))
+    assert ma.allclose(result_ma_nomask, expected_nomask)
+
+    # Regrid with a fully masked array.
+    result_fullmask = rg.regrid(ma.array(src_array, mask=True))
+    expected_fulmask = ma.array(np.zeros([3, 2]), mask=True)
+    assert ma.allclose(result_fullmask, expected_fulmask)
+
+    # Regrid with a masked array containing a masked point.
+    result_withmask = rg.regrid(src_masked)
+    expected_withmask = ma.array(
+        [
+            [0.9999999999999999, 1.0],
+            [0.7503444126612077, 0.4999999999999997],
+            [0.6674194025656824, 0.0],
+        ]
+    )
+    assert ma.allclose(result_withmask, expected_withmask)
+
+    # Regrid while setting mdtol.
+    result_half_mdtol = rg.regrid(src_masked, mdtol=0.5)
+    expected_half_mdtol = ma.array(expected_withmask, mask=[[1, 0], [0, 0], [1, 0]])
+    assert ma.allclose(result_half_mdtol, expected_half_mdtol)
+
+    # Regrid with norm_type="DSTAREA".
+    result_dstarea = rg.regrid(src_masked, norm_type="DSTAREA")
+    expected_dstarea = ma.array(
+        [
+            [0.3325805974343169, 0.9999999999999998],
+            [0.4999999999999999, 0.499931367542066],
+            [0.6674194025656823, 0.0],
+        ]
+    )
+    assert ma.allclose(result_dstarea, expected_dstarea)

--- a/esmf_regrid/tests/unit/esmf_regridder/test_Regridder.py
+++ b/esmf_regrid/tests/unit/esmf_regridder/test_Regridder.py
@@ -127,6 +127,3 @@ def test_Regridder_regrid():
         ]
     )
     assert ma.allclose(result_dstarea, expected_dstarea)
-
-
-test_Regridder_init()

--- a/esmf_regrid/tests/unit/esmf_regridder/test_Regridder.py
+++ b/esmf_regrid/tests/unit/esmf_regridder/test_Regridder.py
@@ -5,20 +5,20 @@ from numpy import ma
 import scipy.sparse
 
 from esmf_regrid.esmf_regridder import GridInfo, Regridder
+from esmf_regrid.tests import make_grid_args
 
-
-def _make_small_grid_args(x, y):
-    small_grid_lon = np.array(range(x)) * 10 / x
-    small_grid_lat = np.array(range(y)) * 10 / y
-
-    small_grid_lon_bounds = np.array(range(x + 1)) * 10 / x
-    small_grid_lat_bounds = np.array(range(y + 1)) * 10 / y
-    return (
-        small_grid_lon,
-        small_grid_lat,
-        small_grid_lon_bounds,
-        small_grid_lat_bounds,
-    )
+# def _make_grid_args(x, y):
+#     small_grid_lon = np.array(range(x)) * 10 / x
+#     small_grid_lat = np.array(range(y)) * 10 / y
+#
+#     small_grid_lon_bounds = np.array(range(x + 1)) * 10 / x
+#     small_grid_lat_bounds = np.array(range(y + 1)) * 10 / y
+#     return (
+#         small_grid_lon,
+#         small_grid_lat,
+#         small_grid_lon_bounds,
+#         small_grid_lat_bounds,
+#     )
 
 
 def _expected_weights():
@@ -53,10 +53,10 @@ def _expected_weights():
 
 def test_Regridder_init():
     """Basic test for :meth:`~esmf_regrid.esmf_regridder.Regridder.__init__`."""
-    lon, lat, lon_bounds, lat_bounds = _make_small_grid_args(2, 3)
+    lon, lat, lon_bounds, lat_bounds = make_grid_args(2, 3)
     src_grid = GridInfo(lon, lat, lon_bounds, lat_bounds)
 
-    lon, lat, lon_bounds, lat_bounds = _make_small_grid_args(3, 2)
+    lon, lat, lon_bounds, lat_bounds = make_grid_args(3, 2)
     tgt_grid = GridInfo(lon, lat, lon_bounds, lat_bounds)
 
     rg = Regridder(src_grid, tgt_grid)
@@ -69,10 +69,10 @@ def test_Regridder_init():
 
 def test_Regridder_regrid():
     """Basic test for :meth:`~esmf_regrid.esmf_regridder.Regridder.regrid`."""
-    lon, lat, lon_bounds, lat_bounds = _make_small_grid_args(2, 3)
+    lon, lat, lon_bounds, lat_bounds = make_grid_args(2, 3)
     src_grid = GridInfo(lon, lat, lon_bounds, lat_bounds)
 
-    lon, lat, lon_bounds, lat_bounds = _make_small_grid_args(3, 2)
+    lon, lat, lon_bounds, lat_bounds = make_grid_args(3, 2)
     tgt_grid = GridInfo(lon, lat, lon_bounds, lat_bounds)
 
     # Set up the regridder with precomputed weights.
@@ -127,3 +127,6 @@ def test_Regridder_regrid():
         ]
     )
     assert ma.allclose(result_dstarea, expected_dstarea)
+
+
+test_Regridder_init()

--- a/esmf_regrid/tests/unit/esmf_regridder/test_Regridder.py
+++ b/esmf_regrid/tests/unit/esmf_regridder/test_Regridder.py
@@ -2,40 +2,42 @@
 
 import numpy as np
 from numpy import ma
-import scipy.sparse
+import sparse
 
 from esmf_regrid.esmf_regridder import GridInfo, Regridder
 from esmf_regrid.tests import make_grid_args
 
 
 def _expected_weights():
-    weight_list = np.array(
+    weights = np.array(
         [
             0.6674194025656819,
+            0.33363933739884066,
             0.3325805974343169,
             0.3351257294386341,
-            0.6648742705613656,
-            0.33363933739884066,
             0.1663606626011589,
-            0.333639337398841,
-            0.1663606626011591,
             0.16742273275056854,
+            0.6648742705613656,
             0.33250863479149745,
-            0.16742273275056876,
-            0.33250863479149767,
+            0.333639337398841,
             0.6674194025656823,
+            0.1663606626011591,
+            0.16742273275056876,
             0.3325805974343174,
             0.3351257294386344,
+            0.33250863479149767,
             0.6648742705613663,
         ]
     )
-    rows = np.array([0, 0, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3, 4, 4, 5, 5])
-    columns = np.array([0, 1, 1, 2, 0, 1, 3, 4, 1, 2, 4, 5, 3, 4, 4, 5])
+    coords = np.array([[0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1],
+                       [0, 0, 1, 1, 1, 1, 2, 2, 0, 0, 1, 1, 1, 1, 2, 2],
+                       [0, 1, 0, 0, 1, 1, 0, 1, 1, 2, 1, 1, 2, 2, 1, 2],
+                       [0, 0, 0, 1, 0, 1, 1, 1, 0, 0, 0, 1, 0, 1, 1, 1]])
 
-    shape = (6, 6)
+    shape = (2, 3, 3, 2)
 
-    weights = scipy.sparse.csr_matrix((weight_list, (rows, columns)), shape=shape)
-    return weights
+    weights_tensor = sparse.COO(coords, weights, shape=shape)
+    return weights_tensor
 
 
 def test_Regridder_init():
@@ -48,10 +50,10 @@ def test_Regridder_init():
 
     rg = Regridder(src_grid, tgt_grid)
 
-    result = rg.weight_matrix
+    result = rg.weights
     expected = _expected_weights()
 
-    assert np.allclose(result.toarray(), expected.toarray())
+    assert np.allclose(result.todense(), expected.todense())
 
 
 def test_Regridder_regrid():

--- a/esmf_regrid/tests/unit/esmf_regridder/test_Regridder.py
+++ b/esmf_regrid/tests/unit/esmf_regridder/test_Regridder.py
@@ -1,11 +1,10 @@
 """Unit tests for :class:`esmf_regrid.esmf_regridder.Regridder`."""
 
 import numpy as np
-
-from esmf_regrid.esmf_regridder import GridInfo, Regridder
-import esmf_regrid.tests as tests
 from numpy import ma
 import scipy.sparse
+
+from esmf_regrid.esmf_regridder import GridInfo, Regridder
 
 
 def _make_small_grid_args(x, y):

--- a/requirements/py36.yml
+++ b/requirements/py36.yml
@@ -14,6 +14,7 @@ dependencies:
   - numpy>=1.14
   - scipy
   - esmpy>=7.0
+  - sparse
 
 # Test dependencies.
   - black=20.8b1

--- a/requirements/py37.yml
+++ b/requirements/py37.yml
@@ -14,6 +14,7 @@ dependencies:
   - numpy>=1.14
   - scipy
   - esmpy>=7.0
+  - sparse
 
 # Test dependencies.
   - black=20.8b1

--- a/requirements/py38.yml
+++ b/requirements/py38.yml
@@ -14,6 +14,7 @@ dependencies:
   - numpy>=1.14
   - scipy
   - esmpy>=7.0
+  - sparse
 
 # Test dependencies.
   - black=20.8b1


### PR DESCRIPTION
Move from scipy sparse matrices to sparse arrays using the [sparse library](https://sparse.pydata.org). This simplifies the index gymnastics a bit, avoid the special numpy matrix interface (cf [the note at the top of here](https://numpy.org/doc/stable/reference/generated/numpy.matrix.html)), and should allow us to work with dask a bit more easily.

Draft PR for now since it is built on #22 and should be seen as proof of concept.