### PR TITLE
Add unstructured mesh support with MeshInfo

### DIFF
--- a/esmf_regrid/esmf_regridder.py
+++ b/esmf_regrid/esmf_regridder.py
@@ -15,7 +15,7 @@ __all__ = [
 
 class GridInfo:
     """
-    TBD: public class docstring summary (one line).
+    Class for handling structured grids
 
     This class holds information about lat-lon type grids. That is, grids
     defined by lists of latitude and longitude values for points/bounds
@@ -160,13 +160,13 @@ class GridInfo:
         return grid
 
     def make_esmf_field(self):
-        """TBD: public method docstring."""
+        """Return an ESMF field representing the grid."""
         grid = self._make_esmf_grid()
         field = ESMF.Field(grid, staggerloc=ESMF.StaggerLoc.CENTER)
         return field
 
     def size(self):
-        """TBD: public method docstring."""
+        """Return the number of cells in the grid."""
         return len(self.lons) * len(self.lats)
 
     def _index_offset(self):

--- a/esmf_regrid/esmf_regridder.py
+++ b/esmf_regrid/esmf_regridder.py
@@ -15,7 +15,7 @@ __all__ = [
 
 class GridInfo:
     """
-    Class for handling structured grids
+    Class for handling structured grids.
 
     This class holds information about lat-lon type grids. That is, grids
     defined by lists of latitude and longitude values for points/bounds

--- a/esmf_regrid/experimental/__init__.py
+++ b/esmf_regrid/experimental/__init__.py
@@ -1,0 +1,1 @@
+"""Experimental code can be introduced to Iris-esmf-regrid through this package."""

--- a/esmf_regrid/experimental/unstructured_regrid.py
+++ b/esmf_regrid/experimental/unstructured_regrid.py
@@ -25,11 +25,10 @@ class MeshInfo:
         areas=None,
     ):
         """
-        Creates a MeshInfo object describing a UGRID-like mesh.
+        Create a MeshInfo object describing a UGRID-like mesh.
 
         Parameters
         ----------
-
         node_coords: array_like
             An Nx2 numpy array describing the location of the nodes of the mesh.
             node_coords[:,0] describes the longitudes in degrees and

--- a/esmf_regrid/experimental/unstructured_regrid.py
+++ b/esmf_regrid/experimental/unstructured_regrid.py
@@ -33,7 +33,7 @@ class MeshInfo:
         node_coords: array_like
             An Nx2 numpy array describing the location of the nodes of the mesh.
             node_coords[:,0] describes the longitudes in degrees and
-            node_coords[:,1] describes the latitides in degrees
+            node_coords[:,1] describes the latitudes in degrees
         face_node_connectivity: array_like
             A numpy masked array describing the face node connectivity of the
             mesh. The unmasked points of face_node_connectivity[i] describe

--- a/esmf_regrid/experimental/unstructured_regrid.py
+++ b/esmf_regrid/experimental/unstructured_regrid.py
@@ -1,0 +1,127 @@
+"""Provides ESMF representations of UGRID meshes."""
+
+import ESMF
+import numpy as np
+import cartopy.crs as ccrs
+
+
+class MeshInfo:
+    """
+    This class holds information about Meshes in a form similar to UGRID.
+    It contains methods for translating this information into ESMF objects.
+    In particular, there are methods for representing as an ESMF Mesh and
+    as an ESMF Field containing that Mesh. This ESMF Field is designed to
+    contain enough information for area weighted regridding and may be
+    inappropriate for other ESMF regridding schemes.
+    """
+
+    def __init__(
+        self,
+        node_coords,
+        face_node_connectivity,
+        node_start_index,
+        elem_start_index=0,
+        areas=None,
+    ):
+        """
+        Creates a MeshInfo object describing the geometry/topology of a UGRID
+        mesh.
+
+        Args:
+
+        * node_coords
+            An Nx2 numpy array describing the location of the nodes of the mesh.
+            node_coords[:,0] describes the longitudes in degrees and
+            node_coords[:,1] describes the latitides in degrees
+        * face_node_connectivity
+            A numpy masked array describing the face node connectivity of the
+            mesh. The unmasked points of face_node_connectivity[i] describe
+            which nodes are connected to the i'th face.
+        * node_start_index
+            An integer the value which, appearing in the face_node_connectivity
+            array, indicates the first node in the node_coords array.
+            UGRID supports both 0 based and 1 based indexing, so both must be
+            accounted for here:
+            https://ugrid-conventions.github.io/ugrid-conventions/#zero-or-one
+
+        Kwargs:
+
+        * elem_start_index
+            An integer describing what index should be considered by ESMF to be
+            the start index for describing its elements. This makes no
+            difference to the regridding calculation and will only affect the
+            intermediate ESMF objects, should the user need access to them.
+        * areas
+            either None or a numpy array describing the areas associated with
+            each face. If None, then ESMF will use its own calculated areas.
+        """
+        self.node_coords = node_coords
+        self.fnc = face_node_connectivity
+        self.nsi = node_start_index
+        self.esi = elem_start_index
+        self.areas = areas
+
+    def _as_esmf_info(self):
+        # ESMF uses a slightly different format to UGRID,
+        # the data must be translated into a form ESMF understands
+        num_node = self.node_coords.shape[0]
+        num_elem = self.fnc.shape[0]
+        nodeId = np.array(range(self.nsi, self.nsi + num_node))
+        nodeCoord = self.node_coords.flatten()
+        nodeOwner = np.zeros([num_node])  # regridding currently serial
+        elemId = np.array(range(self.esi, self.esi + num_elem))
+        elemType = self.fnc.count(axis=1)
+        # Experiments seem to indicate that ESMF is using 0 indexing here
+        elemConn = self.fnc.compressed() - self.nsi
+        result = (
+            num_node,
+            num_elem,
+            nodeId,
+            nodeCoord,
+            nodeOwner,
+            elemId,
+            elemType,
+            elemConn,
+            self.areas,
+        )
+        return result
+
+    def _make_esmf_mesh(self):
+        info = self._as_esmf_info()
+        (
+            num_node,
+            num_elem,
+            nodeId,
+            nodeCoord,
+            nodeOwner,
+            elemId,
+            elemType,
+            elemConn,
+            areas,
+        ) = info
+        # ESMF can handle other dimensionalities, but we are unlikely
+        # to make such a use of ESMF
+        emesh = ESMF.Mesh(
+            parametric_dim=2, spatial_dim=2, coord_sys=ESMF.CoordSys.SPH_DEG
+        )
+
+        emesh.add_nodes(num_node, nodeId, nodeCoord, nodeOwner)
+        emesh.add_elements(num_elem, elemId, elemType, elemConn, element_area=areas)
+        return emesh
+
+    def make_esmf_field(self):
+        mesh = self._make_esmf_mesh()
+        field = ESMF.Field(mesh, meshloc=ESMF.MeshLoc.ELEMENT)
+        return field
+
+    def size(self):
+        return self.fnc.shape[0]
+
+    def _index_offset(self):
+        return self.esi
+
+    def _flatten_array(self, array):
+        return array
+
+    def _unflatten_array(self, array):
+        return array

--- a/esmf_regrid/experimental/unstructured_regrid.py
+++ b/esmf_regrid/experimental/unstructured_regrid.py
@@ -2,11 +2,12 @@
 
 import ESMF
 import numpy as np
-import cartopy.crs as ccrs
 
 
 class MeshInfo:
     """
+    Class for handling unstructured meshes.
+
     This class holds information about Meshes in a form similar to UGRID.
     It contains methods for translating this information into ESMF objects.
     In particular, there are methods for representing as an ESMF Mesh and
@@ -24,36 +25,35 @@ class MeshInfo:
         areas=None,
     ):
         """
-        Creates a MeshInfo object describing the geometry/topology of a UGRID
-        mesh.
+        Creates a MeshInfo object describing a UGRID-like mesh.
 
-        Args:
+        Parameters
+        ----------
 
-        * node_coords
+        node_coords: array_like
             An Nx2 numpy array describing the location of the nodes of the mesh.
             node_coords[:,0] describes the longitudes in degrees and
             node_coords[:,1] describes the latitides in degrees
-        * face_node_connectivity
+        face_node_connectivity: array_like
             A numpy masked array describing the face node connectivity of the
             mesh. The unmasked points of face_node_connectivity[i] describe
             which nodes are connected to the i'th face.
-        * node_start_index
+        node_start_index: int
             An integer the value which, appearing in the face_node_connectivity
             array, indicates the first node in the node_coords array.
             UGRID supports both 0 based and 1 based indexing, so both must be
             accounted for here:
             https://ugrid-conventions.github.io/ugrid-conventions/#zero-or-one
-
-        Kwargs:
-
-        * elem_start_index
+        elem_start_index: int, optional
             An integer describing what index should be considered by ESMF to be
             the start index for describing its elements. This makes no
             difference to the regridding calculation and will only affect the
             intermediate ESMF objects, should the user need access to them.
-        * areas
-            either None or a numpy array describing the areas associated with
+            Defaults to 0.
+        areas: array_like, optional
+            Either None or a numpy array describing the areas associated with
             each face. If None, then ESMF will use its own calculated areas.
+            Defaults to None.
         """
         self.node_coords = node_coords
         self.fnc = face_node_connectivity
@@ -110,11 +110,13 @@ class MeshInfo:
         return emesh
 
     def make_esmf_field(self):
+        """Return an ESMF field representing the grid."""
         mesh = self._make_esmf_mesh()
         field = ESMF.Field(mesh, meshloc=ESMF.MeshLoc.ELEMENT)
         return field
 
     def size(self):
+        """Return the number of cells in the mesh."""
         return self.fnc.shape[0]
 
     def _index_offset(self):

--- a/esmf_regrid/tests/results/unit/experimental/unstructured_regrid/test_MeshInfo/small_mesh.txt
+++ b/esmf_regrid/tests/results/unit/experimental/unstructured_regrid/test_MeshInfo/small_mesh.txt
@@ -1,0 +1,18 @@
+Field:
+    name = None
+    type = <TypeKind.R8: 6>
+    rank = 1
+    extra dimensions = 0
+    staggerloc = 1
+    lower bounds = array([0], dtype=int32)
+    upper bounds = array([2], dtype=int32)
+    extra bounds = None
+    data = array([0., 0.])
+    grid = 
+Mesh:
+    rank = 1
+    size = [5, 2]
+    size_owned = [5, 2]
+    coords = [[array([ 0.,  0., 10., 10., 10.]), array([ 0., 10.,  0., 10., 20.])], [None, None]]
+
+)

--- a/esmf_regrid/tests/unit/experimental/unstuctured_regrid/test_MeshInfo.py
+++ b/esmf_regrid/tests/unit/experimental/unstuctured_regrid/test_MeshInfo.py
@@ -1,1 +1,61 @@
 """Unit tests for :class:`esmf_regrid.experimental.unstructured_regrid.MeshInfo`."""
+
+import numpy as np
+from numpy import ma
+from esmf_regrid.esmf_regridder import GridInfo, Regridder
+from esmf_regrid.experimental.unstructured_regrid import MeshInfo
+from esmf_regrid.tests import make_grid_args, get_result_path
+
+
+def _make_small_mesh_args():
+    ugrid_node_coords = np.array(
+        [[0.0, 0.0], [0.0, 10.0], [10.0, 0.0], [10.0, 10.0], [10.0, 20.0]]
+    )
+    ugrid_face_node_connectivity = ma.array(
+        [[0, 2, 3, -1], [3, 0, 1, 4]],
+        mask=np.array([[0, 0, 0, 1], [0, 0, 0, 0]]),
+    )
+    node_start_index = 0
+    return ugrid_node_coords, ugrid_face_node_connectivity, node_start_index
+
+def test_make_mesh():
+    coords, nodes, _ = _make_small_mesh_args()
+    mesh_0 = MeshInfo(coords, nodes, 0)
+    esmf_mesh_0 = mesh_0.make_esmf_field()
+    esmf_mesh_0.data[:] = 0
+
+    relative_path = ("experimental", "unstructured_regrid", "test_MeshInfo", "small_mesh.txt")
+    fname = get_result_path(relative_path)
+    with open(fname) as file:
+        expected_repr = file.read()
+
+    one_indexed_nodes = nodes + 1
+    mesh_1 = MeshInfo(coords, one_indexed_nodes, 1)
+    esmf_mesh_1 = mesh_1.make_esmf_field()
+    esmf_mesh_1.data[:] = 0
+
+    assert esmf_mesh_0.__repr__() == esmf_mesh_1.__repr__() == expected_repr
+
+def test_regrid_with_mesh():
+    mesh_args = _make_small_mesh_args()
+    mesh = MeshInfo(*mesh_args)
+
+    grid_args = make_grid_args(2, 3)
+    grid = GridInfo(*grid_args)
+
+    mesh_to_grid_regridder = Regridder(mesh, grid)
+    mesh_input = np.array([3, 2])
+    grid_output = mesh_to_grid_regridder.regrid(mesh_input)
+    expected_grid_output = np.array(
+        [
+            [2.671294712940605, 2.0885553467353097, 2.0],
+            [3.0, 2.9222786250561574, 2.3397940801753307],
+        ]
+    )
+    assert ma.allclose(expected_grid_output, grid_output)
+
+    grid_to_mesh_regridder = Regridder(grid, mesh)
+    grid_input = np.array([[0, 1, 2], [0, 0, 1]])
+    mesh_output = grid_to_mesh_regridder.regrid(grid_input)
+    expected_mesh_output = np.array([0.1408245341331448, 1.19732762534643])
+    assert ma.allclose(expected_mesh_output, mesh_output)

--- a/esmf_regrid/tests/unit/experimental/unstuctured_regrid/test_MeshInfo.py
+++ b/esmf_regrid/tests/unit/experimental/unstuctured_regrid/test_MeshInfo.py
@@ -12,11 +12,11 @@ def _make_small_mesh_args():
         [[0.0, 0.0], [0.0, 10.0], [10.0, 0.0], [10.0, 10.0], [10.0, 20.0]]
     )
     ugrid_face_node_connectivity = ma.array(
-        [[0, 2, 3, -1], [3, 0, 1, 4]],
-        mask=np.array([[0, 0, 0, 1], [0, 0, 0, 0]]),
+        [[0, 2, 3, -1], [3, 0, 1, 4]], mask=np.array([[0, 0, 0, 1], [0, 0, 0, 0]]),
     )
     node_start_index = 0
     return ugrid_node_coords, ugrid_face_node_connectivity, node_start_index
+
 
 def test_make_mesh():
     coords, nodes, _ = _make_small_mesh_args()
@@ -24,7 +24,12 @@ def test_make_mesh():
     esmf_mesh_0 = mesh_0.make_esmf_field()
     esmf_mesh_0.data[:] = 0
 
-    relative_path = ("experimental", "unstructured_regrid", "test_MeshInfo", "small_mesh.txt")
+    relative_path = (
+        "experimental",
+        "unstructured_regrid",
+        "test_MeshInfo",
+        "small_mesh.txt",
+    )
     fname = get_result_path(relative_path)
     with open(fname) as file:
         expected_repr = file.read()
@@ -35,6 +40,7 @@ def test_make_mesh():
     esmf_mesh_1.data[:] = 0
 
     assert esmf_mesh_0.__repr__() == esmf_mesh_1.__repr__() == expected_repr
+
 
 def test_regrid_with_mesh():
     mesh_args = _make_small_mesh_args()

--- a/esmf_regrid/tests/unit/experimental/unstuctured_regrid/test_MeshInfo.py
+++ b/esmf_regrid/tests/unit/experimental/unstuctured_regrid/test_MeshInfo.py
@@ -1,0 +1,1 @@
+"""Unit tests for :class:`esmf_regrid.experimental.unstructured_regrid.MeshInfo`."""

--- a/esmf_regrid/tests/unit/experimental/unstuctured_regrid/test_MeshInfo.py
+++ b/esmf_regrid/tests/unit/experimental/unstuctured_regrid/test_MeshInfo.py
@@ -2,9 +2,10 @@
 
 import numpy as np
 from numpy import ma
+
 from esmf_regrid.esmf_regridder import GridInfo, Regridder
 from esmf_regrid.experimental.unstructured_regrid import MeshInfo
-from esmf_regrid.tests import make_grid_args, get_result_path
+from esmf_regrid.tests import get_result_path, make_grid_args
 
 
 def _make_small_mesh_args():
@@ -12,13 +13,15 @@ def _make_small_mesh_args():
         [[0.0, 0.0], [0.0, 10.0], [10.0, 0.0], [10.0, 10.0], [10.0, 20.0]]
     )
     ugrid_face_node_connectivity = ma.array(
-        [[0, 2, 3, -1], [3, 0, 1, 4]], mask=np.array([[0, 0, 0, 1], [0, 0, 0, 0]]),
+        [[0, 2, 3, -1], [3, 0, 1, 4]],
+        mask=np.array([[0, 0, 0, 1], [0, 0, 0, 0]]),
     )
     node_start_index = 0
     return ugrid_node_coords, ugrid_face_node_connectivity, node_start_index
 
 
 def test_make_mesh():
+    """Basic test for creating :meth:`~esmf_regrid.esmf_regridder.GridInfo.make_esmf_field`."""
     coords, nodes, _ = _make_small_mesh_args()
     mesh_0 = MeshInfo(coords, nodes, 0)
     esmf_mesh_0 = mesh_0.make_esmf_field()
@@ -43,6 +46,7 @@ def test_make_mesh():
 
 
 def test_regrid_with_mesh():
+    """Basic test for regridding with :meth:`~esmf_regrid.esmf_regridder.GridInfo.make_esmf_field`."""
     mesh_args = _make_small_mesh_args()
     mesh = MeshInfo(*mesh_args)
 


### PR DESCRIPTION
This adds back end support for UGRID style unstructured meshes. It is built in anticipation of Iris adding UGRID support and therefore the code is separated into an experimental directory. Adding and testing against this code now ensures that the design of iris-esmf-regrid will maintain the flexibility to add UGRID support when Iris allows it.

This builds on top of #22 and is therefore a draft.