### PR TITLE
Extra dimension handling (previously Dimension priority reorder)

### DIFF
--- a/esmf_regrid/esmf_regridder.py
+++ b/esmf_regrid/esmf_regridder.py
@@ -304,7 +304,7 @@ class Regridder:
                 f"got an array with shape ending in {main_shape}."
             )
         extra_shape = array_shape[: -self.src.dims]
-        extra_size = max(1, sum(extra_shape))
+        extra_size = max(1, np.prod(extra_shape))
         src_inverted_mask = self.src._flatten_array(~ma.getmaskarray(src_array))
         weight_sums = self.weight_matrix * src_inverted_mask
         # Set the minimum mdtol to be slightly higher than 0 to account for rounding

--- a/esmf_regrid/esmf_regridder.py
+++ b/esmf_regrid/esmf_regridder.py
@@ -175,10 +175,10 @@ class GridInfo:
         return 1
 
     def _flatten_array(self, array):
-        return array.flatten(order="F")
+        return array.reshape(-1, (self.size()), order="F").T
 
-    def _unflatten_array(self, array):
-        return array.reshape(self.shape, order="F")
+    def _unflatten_array(self, array, extra_dims):
+        return array.T.reshape(extra_dims + self.shape, order="F")
 
 
 def _get_regrid_weights_dict(src_field, tgt_field):
@@ -303,6 +303,8 @@ class Regridder:
                 f"Expected an array whose shape ends in {self.src.shape}, "
                 f"got an array with shape ending in {main_shape}."
             )
+        extra_shape = array_shape[:-self.src.dims]
+        extra_size = max(1, sum(extra_shape))
         src_inverted_mask = self.src._flatten_array(~ma.getmaskarray(src_array))
         weight_sums = self.weight_matrix * src_inverted_mask
         # Set the minimum mdtol to be slightly higher than 0 to account for rounding
@@ -310,7 +312,7 @@ class Regridder:
         mdtol = max(mdtol, 1e-8)
         tgt_mask = weight_sums > 1 - mdtol
         masked_weight_sums = weight_sums * tgt_mask
-        normalisations = np.ones(self.tgt.size())
+        normalisations = np.ones([self.tgt.size(), extra_size])
         if norm_type == "fracarea":
             normalisations[tgt_mask] /= masked_weight_sums[tgt_mask]
         elif norm_type == "dstarea":
@@ -322,5 +324,5 @@ class Regridder:
         flat_src = self.src._flatten_array(ma.filled(src_array, 0.0))
         flat_tgt = self.weight_matrix * flat_src
         flat_tgt = flat_tgt * normalisations
-        tgt_array = self.tgt._unflatten_array(flat_tgt)
+        tgt_array = self.tgt._unflatten_array(flat_tgt, extra_shape)
         return tgt_array

--- a/esmf_regrid/esmf_regridder.py
+++ b/esmf_regrid/esmf_regridder.py
@@ -303,7 +303,7 @@ class Regridder:
                 f"Expected an array whose shape ends in {self.src.shape}, "
                 f"got an array with shape ending in {main_shape}."
             )
-        extra_shape = array_shape[:-self.src.dims]
+        extra_shape = array_shape[: -self.src.dims]
         extra_size = max(1, sum(extra_shape))
         src_inverted_mask = self.src._flatten_array(~ma.getmaskarray(src_array))
         weight_sums = self.weight_matrix * src_inverted_mask

--- a/esmf_regrid/esmf_regridder.py
+++ b/esmf_regrid/esmf_regridder.py
@@ -186,7 +186,7 @@ class GridInfo:
         We then take the transpose so that matrix multiplication happens over
         the appropriate axes.
         """
-        return array.reshape(-1, (self.size), order="F").T
+        return array.reshape(-1, self.size, order="F").T
 
     def _matrix_to_array(self, array, extra_dims):
         """

--- a/esmf_regrid/esmf_regridder.py
+++ b/esmf_regrid/esmf_regridder.py
@@ -167,6 +167,7 @@ class GridInfo:
         field = ESMF.Field(grid, staggerloc=ESMF.StaggerLoc.CENTER)
         return field
 
+    @property
     def size(self):
         """Return the number of cells in the grid."""
         return len(self.lons) * len(self.lats)
@@ -185,7 +186,7 @@ class GridInfo:
         We then take the transpose so that matrix multiplication happens over
         the appropriate axes.
         """
-        return array.reshape(-1, (self.size()), order="F").T
+        return array.reshape(-1, (self.size), order="F").T
 
     def _matrix_to_array(self, array, extra_dims):
         """
@@ -265,7 +266,7 @@ class Regridder:
             )
             self.weight_matrix = _weights_dict_to_sparse_array(
                 weights_dict,
-                (self.tgt.size(), self.src.size()),
+                (self.tgt.size, self.src.size),
                 (self.tgt._index_offset(), self.src._index_offset()),
             )
         else:
@@ -273,11 +274,11 @@ class Regridder:
                 raise ValueError(
                     "Precomputed weights must be given as a sparse matrix."
                 )
-            if precomputed_weights.shape != (self.tgt.size(), self.src.size()):
+            if precomputed_weights.shape != (self.tgt.size, self.src.size):
                 msg = "Expected precomputed weights to have shape {}, got shape {} instead."
                 raise ValueError(
                     msg.format(
-                        (self.tgt.size(), self.src.size()),
+                        (self.tgt.size, self.src.size),
                         precomputed_weights.shape,
                     )
                 )
@@ -327,7 +328,7 @@ class Regridder:
         mdtol = max(mdtol, 1e-8)
         tgt_mask = weight_sums > 1 - mdtol
         masked_weight_sums = weight_sums * tgt_mask
-        normalisations = np.ones([self.tgt.size(), extra_size])
+        normalisations = np.ones([self.tgt.size, extra_size])
         if norm_type == "fracarea":
             normalisations[tgt_mask] /= masked_weight_sums[tgt_mask]
         elif norm_type == "dstarea":

--- a/esmf_regrid/experimental/unstructured_regrid.py
+++ b/esmf_regrid/experimental/unstructured_regrid.py
@@ -123,8 +123,23 @@ class MeshInfo:
     def _index_offset(self):
         return self.esi
 
-    def _flatten_array(self, array):
+    def _array_to_matrix(self, array):
+        """
+        Reshape data to a form that is compatible with weight matrices.
+
+        The data should be presented in the form of a matrix (i.e. 2D) in order
+        to be compatible with the weight matrix.
+        Weight matrices deriving from ESMF use fortran ordering when flattening
+        grids to determine cell indices so we use the same order for reshaping.
+        We then take the transpose so that matrix multiplication happens over
+        the appropriate axes.
+        """
         return array.reshape(-1, (self.size()), order="F").T
 
-    def _unflatten_array(self, array, extra_dims):
+    def _matrix_to_array(self, array, extra_dims):
+        """
+        Reshape data to restore original dimensions.
+
+        This is the inverse operation of `_array_to_matrix`.
+        """
         return array.T.reshape(extra_dims + self.shape, order="F")

--- a/esmf_regrid/experimental/unstructured_regrid.py
+++ b/esmf_regrid/experimental/unstructured_regrid.py
@@ -116,6 +116,7 @@ class MeshInfo:
         field = ESMF.Field(mesh, meshloc=ESMF.MeshLoc.ELEMENT)
         return field
 
+    @property
     def size(self):
         """Return the number of cells in the mesh."""
         return self.shape[0]
@@ -134,7 +135,7 @@ class MeshInfo:
         We then take the transpose so that matrix multiplication happens over
         the appropriate axes.
         """
-        return array.reshape(-1, (self.size()), order="F").T
+        return array.reshape(-1, (self.size), order="F").T
 
     def _matrix_to_array(self, array, extra_dims):
         """

--- a/esmf_regrid/experimental/unstructured_regrid.py
+++ b/esmf_regrid/experimental/unstructured_regrid.py
@@ -124,7 +124,7 @@ class MeshInfo:
         return self.esi
 
     def _flatten_array(self, array):
-        return array
+        return array.reshape(-1, (self.size()), order="F").T
 
-    def _unflatten_array(self, array):
-        return array
+    def _unflatten_array(self, array, extra_dims):
+        return array.T.reshape(extra_dims + self.shape, order="F")

--- a/esmf_regrid/experimental/unstructured_regrid.py
+++ b/esmf_regrid/experimental/unstructured_regrid.py
@@ -135,7 +135,7 @@ class MeshInfo:
         We then take the transpose so that matrix multiplication happens over
         the appropriate axes.
         """
-        return array.reshape(-1, (self.size), order="F").T
+        return array.reshape(-1, self.size, order="F").T
 
     def _matrix_to_array(self, array, extra_dims):
         """

--- a/esmf_regrid/tests/integration/esmf_regridder/test_Regridder.py
+++ b/esmf_regrid/tests/integration/esmf_regridder/test_Regridder.py
@@ -20,14 +20,14 @@ def test_esmpy_normalisation():
             [1.0, 0.0],
             [1.0, 0.0],
         ],
-    )
+    ).T
     src_mask = np.array(
         [
             [True, False],
             [False, False],
             [False, False],
         ]
-    )
+    ).T
     src_array = ma.array(src_data, mask=src_mask)
 
     lon, lat, lon_bounds, lat_bounds = make_grid_args(2, 3)

--- a/esmf_regrid/tests/integration/esmf_regridder/test_Regridder.py
+++ b/esmf_regrid/tests/integration/esmf_regridder/test_Regridder.py
@@ -20,14 +20,14 @@ def test_esmpy_normalisation():
             [1.0, 0.0],
             [1.0, 0.0],
         ],
-    ).T
+    )
     src_mask = np.array(
         [
             [True, False],
             [False, False],
             [False, False],
         ]
-    ).T
+    )
     src_array = ma.array(src_data, mask=src_mask)
 
     lon, lat, lon_bounds, lat_bounds = make_grid_args(2, 3)

--- a/esmf_regrid/tests/unit/esmf_regridder/test_Regridder.py
+++ b/esmf_regrid/tests/unit/esmf_regridder/test_Regridder.py
@@ -119,6 +119,7 @@ def test_Regridder_regrid():
         result = np.stack([array, array + 1])
         result = np.stack([result, result + 10, result + 100])
         return result
+
     extra_dim_src = _give_extra_dims(src_array)
     extra_dim_expected = _give_extra_dims(expected_nomask)
 

--- a/esmf_regrid/tests/unit/esmf_regridder/test_Regridder.py
+++ b/esmf_regrid/tests/unit/esmf_regridder/test_Regridder.py
@@ -128,7 +128,7 @@ def test_Regridder_regrid():
     assert ma.allclose(extra_dim_result, extra_dim_expected)
 
     # Regrid extra dimensions with different masks.
-    mixed_mask_src = np.stack([src_array, src_masked])
+    mixed_mask_src = ma.stack([src_array, src_masked])
     mixed_mask_expected = np.stack([expected_nomask, expected_withmask])
 
     mixed_mask_result = rg.regrid(mixed_mask_src)

--- a/esmf_regrid/tests/unit/esmf_regridder/test_Regridder.py
+++ b/esmf_regrid/tests/unit/esmf_regridder/test_Regridder.py
@@ -120,11 +120,19 @@ def test_Regridder_regrid():
         result = np.stack([result, result + 10, result + 100])
         return result
 
+    # Regrid with multiple extra dimensions.
     extra_dim_src = _give_extra_dims(src_array)
     extra_dim_expected = _give_extra_dims(expected_nomask)
 
     extra_dim_result = rg.regrid(extra_dim_src)
     assert ma.allclose(extra_dim_result, extra_dim_expected)
+
+    # Regrid extra dimensions with different masks.
+    mixed_mask_src = np.stack([src_array, src_masked])
+    mixed_mask_expected = np.stack([expected_nomask, expected_withmask])
+
+    mixed_mask_result = rg.regrid(mixed_mask_src)
+    assert ma.allclose(mixed_mask_result, mixed_mask_expected)
 
     assert src_array.T.shape != src_array.shape
     with pytest.raises(ValueError):

--- a/esmf_regrid/tests/unit/esmf_regridder/test_Regridder.py
+++ b/esmf_regrid/tests/unit/esmf_regridder/test_Regridder.py
@@ -115,6 +115,12 @@ def test_Regridder_regrid():
     )
     assert ma.allclose(result_dstarea, expected_dstarea)
 
+    double_src = np.stack([src_array, src_array + 1])
+    double_expected = np.stack([expected_nomask, expected_nomask + 1])
+
+    double_result = rg.regrid(double_src)
+    assert ma.allclose(double_result, double_expected)
+
     assert src_array.T.shape != src_array.shape
     with pytest.raises(ValueError):
         _ = rg.regrid(src_array.T)

--- a/esmf_regrid/tests/unit/esmf_regridder/test_Regridder.py
+++ b/esmf_regrid/tests/unit/esmf_regridder/test_Regridder.py
@@ -115,11 +115,15 @@ def test_Regridder_regrid():
     )
     assert ma.allclose(result_dstarea, expected_dstarea)
 
-    double_src = np.stack([src_array, src_array + 1])
-    double_expected = np.stack([expected_nomask, expected_nomask + 1])
+    def _give_extra_dims(array):
+        result = np.stack([array, array + 1])
+        result = np.stack([result, result + 10, result + 100])
+        return result
+    extra_dim_src = _give_extra_dims(src_array)
+    extra_dim_expected = _give_extra_dims(expected_nomask)
 
-    double_result = rg.regrid(double_src)
-    assert ma.allclose(double_result, double_expected)
+    extra_dim_result = rg.regrid(extra_dim_src)
+    assert ma.allclose(extra_dim_result, extra_dim_expected)
 
     assert src_array.T.shape != src_array.shape
     with pytest.raises(ValueError):

--- a/esmf_regrid/tests/unit/experimental/unstuctured_regrid/test_MeshInfo.py
+++ b/esmf_regrid/tests/unit/experimental/unstuctured_regrid/test_MeshInfo.py
@@ -71,16 +71,17 @@ def test_regrid_with_mesh():
     expected_mesh_output = np.array([0.1408245341331448, 1.19732762534643])
     assert ma.allclose(expected_mesh_output, mesh_output)
 
-    double_mesh_input = np.stack([mesh_input, mesh_input + 1])
-    double_grid_output = mesh_to_grid_regridder.regrid(double_mesh_input)
-    double_expected_grid_output = np.stack(
-        [expected_grid_output, expected_grid_output + 1]
-    )
-    assert ma.allclose(double_expected_grid_output, double_grid_output)
+    def _give_extra_dims(array):
+        result = np.stack([array, array + 1])
+        result = np.stack([result, result + 10, result + 100])
+        return result
 
-    double_grid_input = np.stack([grid_input, grid_input + 1])
-    double_mesh_output = grid_to_mesh_regridder.regrid(double_grid_input)
-    double_expected_mesh_output = np.stack(
-        [expected_mesh_output, expected_mesh_output + 1]
-    )
-    assert ma.allclose(double_expected_mesh_output, double_mesh_output)
+    extra_dim_mesh_input = _give_extra_dims(mesh_input)
+    extra_dim_grid_output = mesh_to_grid_regridder.regrid(extra_dim_mesh_input)
+    extra_dim_expected_grid_output = _give_extra_dims(expected_grid_output)
+    assert ma.allclose(extra_dim_expected_grid_output, extra_dim_grid_output)
+
+    extra_dim_grid_input = _give_extra_dims(grid_input)
+    extra_dim_mesh_output = grid_to_mesh_regridder.regrid(extra_dim_grid_input)
+    extra_dim_expected_mesh_output = _give_extra_dims(expected_mesh_output)
+    assert ma.allclose(extra_dim_expected_mesh_output, extra_dim_mesh_output)

--- a/esmf_regrid/tests/unit/experimental/unstuctured_regrid/test_MeshInfo.py
+++ b/esmf_regrid/tests/unit/experimental/unstuctured_regrid/test_MeshInfo.py
@@ -73,10 +73,14 @@ def test_regrid_with_mesh():
 
     double_mesh_input = np.stack([mesh_input, mesh_input + 1])
     double_grid_output = mesh_to_grid_regridder.regrid(double_mesh_input)
-    double_expected_grid_output = np.stack([expected_grid_output, expected_grid_output + 1])
+    double_expected_grid_output = np.stack(
+        [expected_grid_output, expected_grid_output + 1]
+    )
     assert ma.allclose(double_expected_grid_output, double_grid_output)
 
     double_grid_input = np.stack([grid_input, grid_input + 1])
     double_mesh_output = grid_to_mesh_regridder.regrid(double_grid_input)
-    double_expected_mesh_output = np.stack([expected_mesh_output, expected_mesh_output + 1])
+    double_expected_mesh_output = np.stack(
+        [expected_mesh_output, expected_mesh_output + 1]
+    )
     assert ma.allclose(double_expected_mesh_output, double_mesh_output)

--- a/esmf_regrid/tests/unit/experimental/unstuctured_regrid/test_MeshInfo.py
+++ b/esmf_regrid/tests/unit/experimental/unstuctured_regrid/test_MeshInfo.py
@@ -70,3 +70,13 @@ def test_regrid_with_mesh():
     mesh_output = grid_to_mesh_regridder.regrid(grid_input)
     expected_mesh_output = np.array([0.1408245341331448, 1.19732762534643])
     assert ma.allclose(expected_mesh_output, mesh_output)
+
+    double_mesh_input = np.stack([mesh_input, mesh_input + 1])
+    double_grid_output = mesh_to_grid_regridder.regrid(double_mesh_input)
+    double_expected_grid_output = np.stack([expected_grid_output, expected_grid_output + 1])
+    assert ma.allclose(double_expected_grid_output, double_grid_output)
+
+    double_grid_input = np.stack([grid_input, grid_input + 1])
+    double_mesh_output = grid_to_mesh_regridder.regrid(double_grid_input)
+    double_expected_mesh_output = np.stack([expected_mesh_output, expected_mesh_output + 1])
+    assert ma.allclose(double_expected_mesh_output, double_mesh_output)


### PR DESCRIPTION
### Original Description

Fixes #27. This PR changes the order in which the regridder expects the dimensions of incoming and outgoing data to be ordered to better reflect those described by [CF conventions](http://cfconventions.org/Data/cf-conventions/cf-conventions-1.7/cf-conventions.html#dimensions). That is, data is expected to be ordered such that longitude is the last dimension and latitude is the second to last dimension. A side effect of the more comprehensive approach I have taken is that it is now possible to regrid data with additional non-horizontal dimensions (which has been accounted for with additional tests).

This reordering is largely confined to the code in the `_flatten_array`/`_unflatten_array` methods. These have become more complex than before, which I believe is due to a mismatch in the way ESMF orders dimensions (this is possibly due to ESMF written in Fortran). With that said, the code for `_flatten_array`/`_unflatten_array` in `MeshInfo` and `GridInfo` is now unified.

It's worth noting, and is demonstrated by initial commits, that the all tests still work so long as the original data is transposed.

### New Description

The part of this PR concerned with the reordering of latitude/longitude has now been handled by #30. This PR has been rebased on top of that and now this PR is only concerned with the handling of additional data dimensions.

This PR allows for the regridding of data with dimensions not associated with the horizontal grid/mesh. These extra dimensions must precede the grid/mesh dimensions (as suggested by [CF conventions](http://cfconventions.org/Data/cf-conventions/cf-conventions-1.7/cf-conventions.html#dimensions)). We effectively broadcast the regridding operation defined on the grid/mesh dimensions over all extra dimensions.