### PR TITLE
fix bash octal date

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -35,7 +35,7 @@ lint_task:
     folder: ~/.cache/pip
     fingerprint_script:
       - echo "${CIRRUS_OS} py${PYTHON_VERSION}"
-      - echo "$(date +%Y).$(($(date +%U) / ${CACHE_PERIOD})):${PIP_CACHE_BUILD} ${PIP_CACHE_PACKAGES}"
+      - echo "$(date +%Y).$(($(echo $(date +%U) | sed 's/^0*//') / ${CACHE_PERIOD})):${PIP_CACHE_BUILD} ${PIP_CACHE_PACKAGES}"
   lint_script:
     - pip list
     - python -m pip install --retries 3 --upgrade ${PIP_CACHE_PACKAGES}
@@ -53,7 +53,7 @@ style_task:
     folder: ~/.cache/pip
     fingerprint_script:
       - echo "${CIRRUS_OS} py${PYTHON_VERSION}"
-      - echo "$(date +%Y).$(($(date +%U) / ${CACHE_PERIOD})):${PIP_CACHE_BUILD} ${PIP_CACHE_PACKAGES}"
+      - echo "$(date +%Y).$(($(echo $(date +%U) | sed 's/^0*//') / ${CACHE_PERIOD})):${PIP_CACHE_BUILD} ${PIP_CACHE_PACKAGES}"
   style_script:
     - pip list
     - python -m pip install --retries 3 --upgrade ${PIP_CACHE_PACKAGES}
@@ -87,7 +87,7 @@ linux_task:
     fingerprint_script:
       - wget --quiet https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
       - echo "${CIRRUS_OS} $(sha256sum miniconda.sh)"
-      - echo "$(date +%Y).$(($(date +%U) / ${CACHE_PERIOD})):${CONDA_CACHE_BUILD}"
+      - echo "$(date +%Y).$(($(echo $(date +%U) | sed 's/^0*//') / ${CACHE_PERIOD})):${CONDA_CACHE_BUILD}"
     populate_script:
       - bash miniconda.sh -b -p ${HOME}/miniconda
       - conda config --set always_yes yes --set changeps1 no
@@ -103,7 +103,7 @@ linux_task:
     folder: ${CIRRUS_WORKING_DIR}/.nox
     fingerprint_script:
       - echo "${CIRRUS_OS} tests ${PY_VER}"
-      - echo "$(date +%Y).$(($(date +%U) / ${CACHE_PERIOD})):${NOX_CACHE_BUILD}"
+      - echo "$(date +%Y).$(($(echo $(date +%U) | sed 's/^0*//') / ${CACHE_PERIOD})):${NOX_CACHE_BUILD}"
       - cat ${CIRRUS_WORKING_DIR}/requirements/py$(echo ${PY_VER} | tr -d ".").yml
       - if [ -n "${COVERAGE}" ]; then echo "${COVERAGE}"; fi
   test_script:
@@ -128,7 +128,7 @@ osx_task:
     fingerprint_script:
       - wget --quiet https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh -O miniconda.sh
       - echo "${CIRRUS_OS} $(shasum -a 256 miniconda.sh)"
-      - echo "$(date +%Y).$(($(date +%U) / ${CACHE_PERIOD})):${CONDA_CACHE_BUILD}"
+      - echo "$(date +%Y).$(($(echo $(date +%U) | sed 's/^0*//') / ${CACHE_PERIOD})):${CONDA_CACHE_BUILD}"
     populate_script:
       - bash miniconda.sh -b -p ${HOME}/miniconda
       - conda config --set always_yes yes --set changeps1 no
@@ -144,7 +144,7 @@ osx_task:
     folder: ${CIRRUS_WORKING_DIR}/.nox
     fingerprint_script:
       - echo "${CIRRUS_OS} tests ${PY_VER}"
-      - echo "$(date +%Y).$(($(date +%U) / ${CACHE_PERIOD})):${NOX_CACHE_BUILD}"
+      - echo "$(date +%Y).$(($(echo $(date +%U) | sed 's/^0*//') / ${CACHE_PERIOD})):${NOX_CACHE_BUILD}"
       - cat ${CIRRUS_WORKING_DIR}/requirements/py$(echo ${PY_VER} | tr -d ".").yml
   test_script:
     - nox --session tests

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -35,7 +35,7 @@ lint_task:
     folder: ~/.cache/pip
     fingerprint_script:
       - echo "${CIRRUS_OS} py${PYTHON_VERSION}"
-      - echo "$(date +%Y).$(($(echo $(date +%U) | sed 's/^0*//') / ${CACHE_PERIOD})):${PIP_CACHE_BUILD} ${PIP_CACHE_PACKAGES}"
+      - echo "$(date +%Y).$(expr $(date +%U) / ${CACHE_PERIOD}):${PIP_CACHE_BUILD} ${PIP_CACHE_PACKAGES}"
   lint_script:
     - pip list
     - python -m pip install --retries 3 --upgrade ${PIP_CACHE_PACKAGES}
@@ -53,7 +53,7 @@ style_task:
     folder: ~/.cache/pip
     fingerprint_script:
       - echo "${CIRRUS_OS} py${PYTHON_VERSION}"
-      - echo "$(date +%Y).$(($(echo $(date +%U) | sed 's/^0*//') / ${CACHE_PERIOD})):${PIP_CACHE_BUILD} ${PIP_CACHE_PACKAGES}"
+      - echo "$(date +%Y).$(expr $(date +%U) / ${CACHE_PERIOD}):${PIP_CACHE_BUILD} ${PIP_CACHE_PACKAGES}"
   style_script:
     - pip list
     - python -m pip install --retries 3 --upgrade ${PIP_CACHE_PACKAGES}
@@ -87,7 +87,7 @@ linux_task:
     fingerprint_script:
       - wget --quiet https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
       - echo "${CIRRUS_OS} $(sha256sum miniconda.sh)"
-      - echo "$(date +%Y).$(($(echo $(date +%U) | sed 's/^0*//') / ${CACHE_PERIOD})):${CONDA_CACHE_BUILD}"
+      - echo "$(date +%Y).$(expr $(date +%U) / ${CACHE_PERIOD}):${CONDA_CACHE_BUILD}"
     populate_script:
       - bash miniconda.sh -b -p ${HOME}/miniconda
       - conda config --set always_yes yes --set changeps1 no
@@ -103,7 +103,7 @@ linux_task:
     folder: ${CIRRUS_WORKING_DIR}/.nox
     fingerprint_script:
       - echo "${CIRRUS_OS} tests ${PY_VER}"
-      - echo "$(date +%Y).$(($(echo $(date +%U) | sed 's/^0*//') / ${CACHE_PERIOD})):${NOX_CACHE_BUILD}"
+      - echo "$(date +%Y).$(expr $(date +%U) / ${CACHE_PERIOD}):${NOX_CACHE_BUILD}"
       - cat ${CIRRUS_WORKING_DIR}/requirements/py$(echo ${PY_VER} | tr -d ".").yml
       - if [ -n "${COVERAGE}" ]; then echo "${COVERAGE}"; fi
   test_script:
@@ -128,7 +128,7 @@ osx_task:
     fingerprint_script:
       - wget --quiet https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh -O miniconda.sh
       - echo "${CIRRUS_OS} $(shasum -a 256 miniconda.sh)"
-      - echo "$(date +%Y).$(($(echo $(date +%U) | sed 's/^0*//') / ${CACHE_PERIOD})):${CONDA_CACHE_BUILD}"
+      - echo "$(date +%Y).$(expr $(date +%U) / ${CACHE_PERIOD}):${CONDA_CACHE_BUILD}"
     populate_script:
       - bash miniconda.sh -b -p ${HOME}/miniconda
       - conda config --set always_yes yes --set changeps1 no
@@ -144,7 +144,7 @@ osx_task:
     folder: ${CIRRUS_WORKING_DIR}/.nox
     fingerprint_script:
       - echo "${CIRRUS_OS} tests ${PY_VER}"
-      - echo "$(date +%Y).$(($(echo $(date +%U) | sed 's/^0*//') / ${CACHE_PERIOD})):${NOX_CACHE_BUILD}"
+      - echo "$(date +%Y).$(expr $(date +%U) / ${CACHE_PERIOD}):${NOX_CACHE_BUILD}"
       - cat ${CIRRUS_WORKING_DIR}/requirements/py$(echo ${PY_VER} | tr -d ".").yml
   test_script:
     - nox --session tests


### PR DESCRIPTION
This PR is a fix to the `.cirrus.yml`, where the output of `$(date +%U)` returns `week number of year, with Sunday as first day of week (00..53)` can be interpreted as an octal number that is out of range e.g., `08`.

This causes `bash` to raise and error, and subsequently for all `cirrus-ci` tasks to fail.
