### PR TITLE
Latlon reorder simplified

### DIFF
--- a/esmf_regrid/esmf_regridder.py
+++ b/esmf_regrid/esmf_regridder.py
@@ -78,9 +78,11 @@ class GridInfo:
             self.crs = crs
         self.circular = circular
         self.areas = areas
+        self.shape = (len(lats), len(lons))
+        self.dims = 2
 
     def _as_esmf_info(self):
-        shape = np.array([len(self.lats), len(self.lons)])
+        shape = np.array(self.shape)
 
         if self.circular:
             adjustedlonbounds = self.lonbounds[:-1]
@@ -173,10 +175,10 @@ class GridInfo:
         return 1
 
     def _flatten_array(self, array):
-        return array.flatten()
+        return array.reshape(-1, (self.size()), order="F").T
 
-    def _unflatten_array(self, array):
-        return array.reshape((len(self.lons), len(self.lats)))
+    def _unflatten_array(self, array, extra_dims):
+        return array.T.reshape(extra_dims + self.shape, order="F")
 
 
 def _get_regrid_weights_dict(src_field, tgt_field):
@@ -294,6 +296,9 @@ class Regridder:
             A numpy array whose shape is compatible with self.tgt.
 
         """
+        array_shape = src_array.shape
+        extra_shape = array_shape[:-self.src.dims]
+        extra_size = max(1, sum(extra_shape))
         src_inverted_mask = self.src._flatten_array(~ma.getmaskarray(src_array))
         weight_sums = self.weight_matrix * src_inverted_mask
         # Set the minimum mdtol to be slightly higher than 0 to account for rounding
@@ -301,7 +306,7 @@ class Regridder:
         mdtol = max(mdtol, 1e-8)
         tgt_mask = weight_sums > 1 - mdtol
         masked_weight_sums = weight_sums * tgt_mask
-        normalisations = np.ones(self.tgt.size())
+        normalisations = np.ones([self.tgt.size(), extra_size])
         if norm_type == "fracarea":
             normalisations[tgt_mask] /= masked_weight_sums[tgt_mask]
         elif norm_type == "dstarea":
@@ -313,5 +318,5 @@ class Regridder:
         flat_src = self.src._flatten_array(ma.filled(src_array, 0.0))
         flat_tgt = self.weight_matrix * flat_src
         flat_tgt = flat_tgt * normalisations
-        tgt_array = self.tgt._unflatten_array(flat_tgt)
+        tgt_array = self.tgt._unflatten_array(flat_tgt, extra_shape)
         return tgt_array

--- a/esmf_regrid/esmf_regridder.py
+++ b/esmf_regrid/esmf_regridder.py
@@ -300,7 +300,7 @@ class Regridder:
         main_shape = array_shape[-self.src.dims :]
         if main_shape != self.src.shape:
             raise ValueError(
-                f"Expected an array with whose shape ends in {self.src.shape}, "
+                f"Expected an array whose shape ends in {self.src.shape}, "
                 f"got an array with shape ending in {main_shape}."
             )
         src_inverted_mask = self.src._flatten_array(~ma.getmaskarray(src_array))

--- a/esmf_regrid/esmf_regridder.py
+++ b/esmf_regrid/esmf_regridder.py
@@ -297,6 +297,12 @@ class Regridder:
 
         """
         array_shape = src_array.shape
+        main_shape = array_shape[-self.src.dims :]
+        if main_shape != self.src.shape:
+            raise ValueError(
+                f"Expected an array with whose shape ends in {self.src.shape}, "
+                f"got an array with shape ending in {main_shape}."
+            )
         extra_shape = array_shape[: -self.src.dims]
         extra_size = max(1, sum(extra_shape))
         src_inverted_mask = self.src._flatten_array(~ma.getmaskarray(src_array))

--- a/esmf_regrid/esmf_regridder.py
+++ b/esmf_regrid/esmf_regridder.py
@@ -297,7 +297,7 @@ class Regridder:
 
         """
         array_shape = src_array.shape
-        extra_shape = array_shape[:-self.src.dims]
+        extra_shape = array_shape[: -self.src.dims]
         extra_size = max(1, sum(extra_shape))
         src_inverted_mask = self.src._flatten_array(~ma.getmaskarray(src_array))
         weight_sums = self.weight_matrix * src_inverted_mask

--- a/esmf_regrid/experimental/unstructured_regrid.py
+++ b/esmf_regrid/experimental/unstructured_regrid.py
@@ -124,7 +124,7 @@ class MeshInfo:
         return self.esi
 
     def _flatten_array(self, array):
-        return array.reshape(-1, (self.size()), order="F").T
+        return array
 
-    def _unflatten_array(self, array, extra_dims):
-        return array.T.reshape(extra_dims + self.shape, order="F")
+    def _unflatten_array(self, array):
+        return array

--- a/esmf_regrid/experimental/unstructured_regrid.py
+++ b/esmf_regrid/experimental/unstructured_regrid.py
@@ -59,6 +59,8 @@ class MeshInfo:
         self.nsi = node_start_index
         self.esi = elem_start_index
         self.areas = areas
+        self.shape = (len(face_node_connectivity),)
+        self.dims = 1
 
     def _as_esmf_info(self):
         # ESMF uses a slightly different format to UGRID,
@@ -116,13 +118,13 @@ class MeshInfo:
 
     def size(self):
         """Return the number of cells in the mesh."""
-        return self.fnc.shape[0]
+        return self.shape[0]
 
     def _index_offset(self):
         return self.esi
 
     def _flatten_array(self, array):
-        return array
+        return array.reshape(-1, (self.size()), order="F").T
 
-    def _unflatten_array(self, array):
-        return array
+    def _unflatten_array(self, array, extra_dims):
+        return array.T.reshape(extra_dims + self.shape, order="F")

--- a/esmf_regrid/tests/integration/esmf_regridder/test_Regridder.py
+++ b/esmf_regrid/tests/integration/esmf_regridder/test_Regridder.py
@@ -16,16 +16,18 @@ def test_esmpy_normalisation():
     """
     src_data = np.array(
         [
-            [1.0, 1.0, 1.0],
-            [1.0, 0.0, 0.0],
+            [1.0, 1.0],
+            [1.0, 0.0],
+            [1.0, 0.0],
         ],
-    ).T
+    )
     src_mask = np.array(
         [
-            [True, False, False],
-            [False, False, False],
+            [True, False],
+            [False, False],
+            [False, False],
         ]
-    ).T
+    )
     src_array = ma.array(src_data, mask=src_mask)
 
     lon, lat, lon_bounds, lat_bounds = make_grid_args(2, 3)

--- a/esmf_regrid/tests/integration/esmf_regridder/test_Regridder.py
+++ b/esmf_regrid/tests/integration/esmf_regridder/test_Regridder.py
@@ -19,22 +19,22 @@ def test_esmpy_normalisation():
             [1.0, 1.0, 1.0],
             [1.0, 0.0, 0.0],
         ],
-    )
+    ).T
     src_mask = np.array(
         [
             [True, False, False],
             [False, False, False],
         ]
-    )
+    ).T
     src_array = ma.array(src_data, mask=src_mask)
 
     lon, lat, lon_bounds, lat_bounds = make_grid_args(2, 3)
     src_grid = GridInfo(lon, lat, lon_bounds, lat_bounds)
     src_esmpy_grid = src_grid._make_esmf_grid()
     src_esmpy_grid.add_item(ESMF.GridItem.MASK, staggerloc=ESMF.StaggerLoc.CENTER)
-    src_esmpy_grid.mask[0][...] = src_mask.T
+    src_esmpy_grid.mask[0][...] = src_mask
     src_field = ESMF.Field(src_esmpy_grid)
-    src_field.data[...] = src_data.T
+    src_field.data[...] = src_data
 
     lon, lat, lon_bounds, lat_bounds = make_grid_args(3, 2)
     tgt_grid = GridInfo(lon, lat, lon_bounds, lat_bounds)
@@ -58,10 +58,10 @@ def test_esmpy_normalisation():
 
     tgt_field_dstarea = esmpy_dstarea_regridder(src_field, tgt_field)
     result_esmpy_dstarea = tgt_field_dstarea.data
-    result_dstarea = regridder.regrid(src_array, norm_type="dstarea").T
+    result_dstarea = regridder.regrid(src_array, norm_type="dstarea")
     assert ma.allclose(result_esmpy_dstarea, result_dstarea)
 
     tgt_field_fracarea = esmpy_fracarea_regridder(src_field, tgt_field)
     result_esmpy_fracarea = tgt_field_fracarea.data
-    result_fracarea = regridder.regrid(src_array, norm_type="fracarea").T
+    result_fracarea = regridder.regrid(src_array, norm_type="fracarea")
     assert ma.allclose(result_esmpy_fracarea, result_fracarea)

--- a/esmf_regrid/tests/unit/esmf_regridder/test_Regridder.py
+++ b/esmf_regrid/tests/unit/esmf_regridder/test_Regridder.py
@@ -66,18 +66,17 @@ def test_Regridder_regrid():
     # Set up the regridder with precomputed weights.
     rg = Regridder(src_grid, tgt_grid, precomputed_weights=_expected_weights())
 
-    src_array = np.array([[1.0, 1.0, 1.0], [1.0, 0.0, 0.0]]).T
-    src_masked = ma.array(src_array, mask=np.array([[1, 0, 0], [0, 0, 0]]).T)
+    src_array = np.array([[1.0, 1.0], [1.0, 0.0], [1.0, 0.0]])
+    src_masked = ma.array(src_array, mask=np.array([[1, 0], [0, 0], [0, 0]]))
 
     # Regrid with unmasked data.
     result_nomask = rg.regrid(src_array)
     expected_nomask = ma.array(
         [
-            [1.0, 1.0],
-            [0.8336393373988409, 0.4999999999999997],
-            [0.6674194025656824, 0.0],
+            [1.0, 0.8336393373988409, 0.6674194025656824],
+            [1.0, 0.4999999999999997, 0.0],
         ]
-    ).T
+    )
     assert ma.allclose(result_nomask, expected_nomask)
 
     # Regrid with an masked array with no masked points.
@@ -86,24 +85,23 @@ def test_Regridder_regrid():
 
     # Regrid with a fully masked array.
     result_fullmask = rg.regrid(ma.array(src_array, mask=True))
-    expected_fulmask = ma.array(np.zeros([3, 2]), mask=True).T
+    expected_fulmask = ma.array(np.zeros([2, 3]), mask=True)
     assert ma.allclose(result_fullmask, expected_fulmask)
 
     # Regrid with a masked array containing a masked point.
     result_withmask = rg.regrid(src_masked)
     expected_withmask = ma.array(
         [
-            [0.9999999999999999, 1.0],
-            [0.7503444126612077, 0.4999999999999997],
-            [0.6674194025656824, 0.0],
+            [0.9999999999999999, 0.7503444126612077, 0.6674194025656824],
+            [1.0, 0.4999999999999997, 0.0],
         ]
-    ).T
+    )
     assert ma.allclose(result_withmask, expected_withmask)
 
     # Regrid while setting mdtol.
     result_half_mdtol = rg.regrid(src_masked, mdtol=0.5)
     expected_half_mdtol = ma.array(
-        expected_withmask, mask=np.array([[1, 0], [0, 0], [1, 0]]).T
+        expected_withmask, mask=np.array([[1, 0, 1], [0, 0, 0]])
     )
     assert ma.allclose(result_half_mdtol, expected_half_mdtol)
 
@@ -111,11 +109,10 @@ def test_Regridder_regrid():
     result_dstarea = rg.regrid(src_masked, norm_type="dstarea")
     expected_dstarea = ma.array(
         [
-            [0.3325805974343169, 0.9999999999999998],
-            [0.4999999999999999, 0.499931367542066],
-            [0.6674194025656823, 0.0],
+            [0.3325805974343169, 0.4999999999999999, 0.6674194025656823],
+            [0.9999999999999998, 0.499931367542066, 0.0],
         ]
-    ).T
+    )
     assert ma.allclose(result_dstarea, expected_dstarea)
 
     double_src = np.stack([src_array, src_array + 1])

--- a/esmf_regrid/tests/unit/esmf_regridder/test_Regridder.py
+++ b/esmf_regrid/tests/unit/esmf_regridder/test_Regridder.py
@@ -176,12 +176,16 @@ def test_Regridder_init_small():
     weights_dict["col_src"] = (
         np.array([1, 2, 4, 5, 2, 3, 5, 6], dtype=np.int32) - tgt_grid._index_offset()
     )
+    # The following weights are calculated from grids on a sphere with great circles
+    # defining the lines. Because of this, weights are not exactly the same as they
+    # would be in euclidean geometry and there are some small additional weights
+    # where the cells would not ordinarily overlap in a euclidean grid.
     weights_dict["weights"] = np.array(
         [
             0.4962897,
-            0.0037103,
+            0.0037103,  # Small weight due to using great circle lines
             0.4962897,
-            0.0037103,
+            0.0037103,  # Small weight due to using great circle lines
             0.25484249,
             0.24076863,
             0.25484249,

--- a/esmf_regrid/tests/unit/esmf_regridder/test_Regridder.py
+++ b/esmf_regrid/tests/unit/esmf_regridder/test_Regridder.py
@@ -124,5 +124,9 @@ def test_Regridder_regrid():
     double_result = rg.regrid(double_src)
     assert ma.allclose(double_result, double_expected)
 
+    assert src_array.T.shape != src_array.shape
+    with pytest.raises(ValueError):
+        _ = rg.regrid(src_array.T)
+
     with pytest.raises(ValueError):
         _ = rg.regrid(src_masked, norm_type="INVALID")

--- a/esmf_regrid/tests/unit/esmf_regridder/test_Regridder.py
+++ b/esmf_regrid/tests/unit/esmf_regridder/test_Regridder.py
@@ -102,7 +102,9 @@ def test_Regridder_regrid():
 
     # Regrid while setting mdtol.
     result_half_mdtol = rg.regrid(src_masked, mdtol=0.5)
-    expected_half_mdtol = ma.array(expected_withmask, mask=np.array([[1, 0], [0, 0], [1, 0]]).T)
+    expected_half_mdtol = ma.array(
+        expected_withmask, mask=np.array([[1, 0], [0, 0], [1, 0]]).T
+    )
     assert ma.allclose(result_half_mdtol, expected_half_mdtol)
 
     # Regrid with norm_type="dstarea".

--- a/esmf_regrid/tests/unit/esmf_regridder/test_Regridder.py
+++ b/esmf_regrid/tests/unit/esmf_regridder/test_Regridder.py
@@ -115,12 +115,6 @@ def test_Regridder_regrid():
     )
     assert ma.allclose(result_dstarea, expected_dstarea)
 
-    double_src = np.stack([src_array, src_array + 1])
-    double_expected = np.stack([expected_nomask, expected_nomask + 1])
-
-    double_result = rg.regrid(double_src)
-    assert ma.allclose(double_result, double_expected)
-
     assert src_array.T.shape != src_array.shape
     with pytest.raises(ValueError):
         _ = rg.regrid(src_array.T)

--- a/esmf_regrid/tests/unit/esmf_regridder/test_Regridder.py
+++ b/esmf_regrid/tests/unit/esmf_regridder/test_Regridder.py
@@ -66,58 +66,58 @@ def test_Regridder_regrid():
     # Set up the regridder with precomputed weights.
     rg = Regridder(src_grid, tgt_grid, precomputed_weights=_expected_weights())
 
-    src_array = np.array([[1.0, 1.0, 1.0], [1.0, 0.0, 0.0]])
-    src_masked = ma.array(src_array, mask=[[1, 0, 0], [0, 0, 0]])
+    src_array = np.array([[1.0, 1.0, 1.0], [1.0, 0.0, 0.0]]).T
+    src_masked = ma.array(src_array, mask=np.array([[1, 0, 0], [0, 0, 0]]).T)
 
     # Regrid with unmasked data.
-    result_nomask = rg.regrid(src_array.T)
+    result_nomask = rg.regrid(src_array)
     expected_nomask = ma.array(
         [
             [1.0, 1.0],
             [0.8336393373988409, 0.4999999999999997],
             [0.6674194025656824, 0.0],
         ]
-    )
-    assert ma.allclose(result_nomask, expected_nomask.T)
+    ).T
+    assert ma.allclose(result_nomask, expected_nomask)
 
     # Regrid with an masked array with no masked points.
-    result_ma_nomask = rg.regrid(ma.array(src_array.T))
-    assert ma.allclose(result_ma_nomask, expected_nomask.T)
+    result_ma_nomask = rg.regrid(ma.array(src_array))
+    assert ma.allclose(result_ma_nomask, expected_nomask)
 
     # Regrid with a fully masked array.
-    result_fullmask = rg.regrid(ma.array(src_array, mask=True).T)
-    expected_fulmask = ma.array(np.zeros([3, 2]), mask=True)
-    assert ma.allclose(result_fullmask, expected_fulmask.T)
+    result_fullmask = rg.regrid(ma.array(src_array, mask=True))
+    expected_fulmask = ma.array(np.zeros([3, 2]), mask=True).T
+    assert ma.allclose(result_fullmask, expected_fulmask)
 
     # Regrid with a masked array containing a masked point.
-    result_withmask = rg.regrid(src_masked.T)
+    result_withmask = rg.regrid(src_masked)
     expected_withmask = ma.array(
         [
             [0.9999999999999999, 1.0],
             [0.7503444126612077, 0.4999999999999997],
             [0.6674194025656824, 0.0],
         ]
-    )
-    assert ma.allclose(result_withmask, expected_withmask.T)
+    ).T
+    assert ma.allclose(result_withmask, expected_withmask)
 
     # Regrid while setting mdtol.
-    result_half_mdtol = rg.regrid(src_masked.T, mdtol=0.5)
-    expected_half_mdtol = ma.array(expected_withmask, mask=[[1, 0], [0, 0], [1, 0]])
-    assert ma.allclose(result_half_mdtol, expected_half_mdtol.T)
+    result_half_mdtol = rg.regrid(src_masked, mdtol=0.5)
+    expected_half_mdtol = ma.array(expected_withmask, mask=np.array([[1, 0], [0, 0], [1, 0]]).T)
+    assert ma.allclose(result_half_mdtol, expected_half_mdtol)
 
     # Regrid with norm_type="dstarea".
-    result_dstarea = rg.regrid(src_masked.T, norm_type="dstarea")
+    result_dstarea = rg.regrid(src_masked, norm_type="dstarea")
     expected_dstarea = ma.array(
         [
             [0.3325805974343169, 0.9999999999999998],
             [0.4999999999999999, 0.499931367542066],
             [0.6674194025656823, 0.0],
         ]
-    )
-    assert ma.allclose(result_dstarea, expected_dstarea.T)
+    ).T
+    assert ma.allclose(result_dstarea, expected_dstarea)
 
-    double_src = np.stack([src_array.T, src_array.T + 1])
-    double_expected = np.stack([expected_nomask.T, expected_nomask.T + 1])
+    double_src = np.stack([src_array, src_array + 1])
+    double_expected = np.stack([expected_nomask, expected_nomask + 1])
 
     double_result = rg.regrid(double_src)
     assert ma.allclose(double_result, double_expected)

--- a/esmf_regrid/tests/unit/esmf_regridder/test_Regridder.py
+++ b/esmf_regrid/tests/unit/esmf_regridder/test_Regridder.py
@@ -70,7 +70,7 @@ def test_Regridder_regrid():
     src_masked = ma.array(src_array, mask=[[1, 0, 0], [0, 0, 0]])
 
     # Regrid with unmasked data.
-    result_nomask = rg.regrid(src_array)
+    result_nomask = rg.regrid(src_array.T)
     expected_nomask = ma.array(
         [
             [1.0, 1.0],
@@ -78,19 +78,19 @@ def test_Regridder_regrid():
             [0.6674194025656824, 0.0],
         ]
     )
-    assert ma.allclose(result_nomask, expected_nomask)
+    assert ma.allclose(result_nomask, expected_nomask.T)
 
     # Regrid with an masked array with no masked points.
-    result_ma_nomask = rg.regrid(ma.array(src_array))
-    assert ma.allclose(result_ma_nomask, expected_nomask)
+    result_ma_nomask = rg.regrid(ma.array(src_array.T))
+    assert ma.allclose(result_ma_nomask, expected_nomask.T)
 
     # Regrid with a fully masked array.
-    result_fullmask = rg.regrid(ma.array(src_array, mask=True))
+    result_fullmask = rg.regrid(ma.array(src_array, mask=True).T)
     expected_fulmask = ma.array(np.zeros([3, 2]), mask=True)
-    assert ma.allclose(result_fullmask, expected_fulmask)
+    assert ma.allclose(result_fullmask, expected_fulmask.T)
 
     # Regrid with a masked array containing a masked point.
-    result_withmask = rg.regrid(src_masked)
+    result_withmask = rg.regrid(src_masked.T)
     expected_withmask = ma.array(
         [
             [0.9999999999999999, 1.0],
@@ -98,15 +98,15 @@ def test_Regridder_regrid():
             [0.6674194025656824, 0.0],
         ]
     )
-    assert ma.allclose(result_withmask, expected_withmask)
+    assert ma.allclose(result_withmask, expected_withmask.T)
 
     # Regrid while setting mdtol.
-    result_half_mdtol = rg.regrid(src_masked, mdtol=0.5)
+    result_half_mdtol = rg.regrid(src_masked.T, mdtol=0.5)
     expected_half_mdtol = ma.array(expected_withmask, mask=[[1, 0], [0, 0], [1, 0]])
-    assert ma.allclose(result_half_mdtol, expected_half_mdtol)
+    assert ma.allclose(result_half_mdtol, expected_half_mdtol.T)
 
     # Regrid with norm_type="dstarea".
-    result_dstarea = rg.regrid(src_masked, norm_type="dstarea")
+    result_dstarea = rg.regrid(src_masked.T, norm_type="dstarea")
     expected_dstarea = ma.array(
         [
             [0.3325805974343169, 0.9999999999999998],
@@ -114,7 +114,13 @@ def test_Regridder_regrid():
             [0.6674194025656823, 0.0],
         ]
     )
-    assert ma.allclose(result_dstarea, expected_dstarea)
+    assert ma.allclose(result_dstarea, expected_dstarea.T)
+
+    double_src = np.stack([src_array.T, src_array.T + 1])
+    double_expected = np.stack([expected_nomask.T, expected_nomask.T + 1])
+
+    double_result = rg.regrid(double_src)
+    assert ma.allclose(double_result, double_expected)
 
     with pytest.raises(ValueError):
         _ = rg.regrid(src_masked, norm_type="INVALID")

--- a/esmf_regrid/tests/unit/esmf_regridder/test_Regridder.py
+++ b/esmf_regrid/tests/unit/esmf_regridder/test_Regridder.py
@@ -159,10 +159,7 @@ def test_Regridder_init_small():
     lat_bounds = np.array([0, 10, 30])
     lon, lat = _get_points(lon_bounds), _get_points(lat_bounds)
     tgt_grid = GridInfo(lon, lat, lon_bounds, lat_bounds)
-    assert tgt_grid.shape == (
-        2,
-        1,
-    )
+    assert tgt_grid.shape == (2, 1)
     assert tgt_grid._index_offset() == 1
 
     rg = Regridder(src_grid, tgt_grid)

--- a/esmf_regrid/tests/unit/experimental/unstuctured_regrid/test_MeshInfo.py
+++ b/esmf_regrid/tests/unit/experimental/unstuctured_regrid/test_MeshInfo.py
@@ -72,10 +72,14 @@ def test_regrid_with_mesh():
 
     double_mesh_input = np.stack([mesh_input, mesh_input + 1])
     double_grid_output = mesh_to_grid_regridder.regrid(double_mesh_input)
-    double_expected_grid_output = np.stack([expected_grid_output, expected_grid_output + 1])
+    double_expected_grid_output = np.stack(
+        [expected_grid_output, expected_grid_output + 1]
+    )
     assert ma.allclose(double_expected_grid_output, double_grid_output)
 
     double_grid_input = np.stack([grid_input, grid_input + 1])
     double_mesh_output = grid_to_mesh_regridder.regrid(double_grid_input)
-    double_expected_mesh_output = np.stack([expected_mesh_output, expected_mesh_output + 1])
+    double_expected_mesh_output = np.stack(
+        [expected_mesh_output, expected_mesh_output + 1]
+    )
     assert ma.allclose(double_expected_mesh_output, double_mesh_output)

--- a/esmf_regrid/tests/unit/experimental/unstuctured_regrid/test_MeshInfo.py
+++ b/esmf_regrid/tests/unit/experimental/unstuctured_regrid/test_MeshInfo.py
@@ -62,10 +62,10 @@ def test_regrid_with_mesh():
             [3.0, 2.9222786250561574, 2.3397940801753307],
         ]
     )
-    assert ma.allclose(expected_grid_output, grid_output)
+    assert ma.allclose(expected_grid_output.T, grid_output)
 
     grid_to_mesh_regridder = Regridder(grid, mesh)
     grid_input = np.array([[0, 1, 2], [0, 0, 1]])
-    mesh_output = grid_to_mesh_regridder.regrid(grid_input)
+    mesh_output = grid_to_mesh_regridder.regrid(grid_input.T)
     expected_mesh_output = np.array([0.1408245341331448, 1.19732762534643])
     assert ma.allclose(expected_mesh_output, mesh_output)

--- a/esmf_regrid/tests/unit/experimental/unstuctured_regrid/test_MeshInfo.py
+++ b/esmf_regrid/tests/unit/experimental/unstuctured_regrid/test_MeshInfo.py
@@ -58,14 +58,15 @@ def test_regrid_with_mesh():
     grid_output = mesh_to_grid_regridder.regrid(mesh_input)
     expected_grid_output = np.array(
         [
-            [2.671294712940605, 2.0885553467353097, 2.0],
-            [3.0, 2.9222786250561574, 2.3397940801753307],
+            [2.671294712940605, 3.0],
+            [2.0885553467353097, 2.9222786250561574],
+            [2.0, 2.3397940801753307],
         ]
-    ).T
+    )
     assert ma.allclose(expected_grid_output, grid_output)
 
     grid_to_mesh_regridder = Regridder(grid, mesh)
-    grid_input = np.array([[0, 1, 2], [0, 0, 1]]).T
+    grid_input = np.array([[0, 0], [1, 0], [2, 1]])
     mesh_output = grid_to_mesh_regridder.regrid(grid_input)
     expected_mesh_output = np.array([0.1408245341331448, 1.19732762534643])
     assert ma.allclose(expected_mesh_output, mesh_output)

--- a/esmf_regrid/tests/unit/experimental/unstuctured_regrid/test_MeshInfo.py
+++ b/esmf_regrid/tests/unit/experimental/unstuctured_regrid/test_MeshInfo.py
@@ -61,11 +61,21 @@ def test_regrid_with_mesh():
             [2.671294712940605, 2.0885553467353097, 2.0],
             [3.0, 2.9222786250561574, 2.3397940801753307],
         ]
-    )
-    assert ma.allclose(expected_grid_output.T, grid_output)
+    ).T
+    assert ma.allclose(expected_grid_output, grid_output)
 
     grid_to_mesh_regridder = Regridder(grid, mesh)
-    grid_input = np.array([[0, 1, 2], [0, 0, 1]])
-    mesh_output = grid_to_mesh_regridder.regrid(grid_input.T)
+    grid_input = np.array([[0, 1, 2], [0, 0, 1]]).T
+    mesh_output = grid_to_mesh_regridder.regrid(grid_input)
     expected_mesh_output = np.array([0.1408245341331448, 1.19732762534643])
     assert ma.allclose(expected_mesh_output, mesh_output)
+
+    double_mesh_input = np.stack([mesh_input, mesh_input + 1])
+    double_grid_output = mesh_to_grid_regridder.regrid(double_mesh_input)
+    double_expected_grid_output = np.stack([expected_grid_output, expected_grid_output + 1])
+    assert ma.allclose(double_expected_grid_output, double_grid_output)
+
+    double_grid_input = np.stack([grid_input, grid_input + 1])
+    double_mesh_output = grid_to_mesh_regridder.regrid(double_grid_input)
+    double_expected_mesh_output = np.stack([expected_mesh_output, expected_mesh_output + 1])
+    assert ma.allclose(double_expected_mesh_output, double_mesh_output)

--- a/esmf_regrid/tests/unit/experimental/unstuctured_regrid/test_MeshInfo.py
+++ b/esmf_regrid/tests/unit/experimental/unstuctured_regrid/test_MeshInfo.py
@@ -70,17 +70,3 @@ def test_regrid_with_mesh():
     mesh_output = grid_to_mesh_regridder.regrid(grid_input)
     expected_mesh_output = np.array([0.1408245341331448, 1.19732762534643])
     assert ma.allclose(expected_mesh_output, mesh_output)
-
-    double_mesh_input = np.stack([mesh_input, mesh_input + 1])
-    double_grid_output = mesh_to_grid_regridder.regrid(double_mesh_input)
-    double_expected_grid_output = np.stack(
-        [expected_grid_output, expected_grid_output + 1]
-    )
-    assert ma.allclose(double_expected_grid_output, double_grid_output)
-
-    double_grid_input = np.stack([grid_input, grid_input + 1])
-    double_mesh_output = grid_to_mesh_regridder.regrid(double_grid_input)
-    double_expected_mesh_output = np.stack(
-        [expected_mesh_output, expected_mesh_output + 1]
-    )
-    assert ma.allclose(double_expected_mesh_output, double_mesh_output)


### PR DESCRIPTION
Split from #28 to reduce the complexity of the individual PRs. This does not handle any extra dimensions and is only responsible for reordering the existing dimensions and adding a check.