### PR TITLE
Unstructured scheme iris source

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -5,7 +5,6 @@
 #   - https://cirrus-ci.org/guide/windows/
 #   - https://hub.docker.com/_/gcc/
 #   - https://hub.docker.com/_/python/
-#   - https://community.codecov.io/t/add-support-of-uploading-from-cirrus-ci-without-token/1028/14
 
 #
 # Global defaults.

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -11,8 +11,14 @@
 #
 container:
   image: python:3.8
+  cpu: 2
+  memory: 4G
 
 env:
+  # Skip specific tasks by name. Set to a non-empty string to skip.
+  SKIP_LINT_TASK: ""
+  SKIP_LINUX_TEST_TASK: ""
+  SKIP_OSX_TEST_TASK: ""
   # Maximum cache period (in weeks) before forcing a new cache upload.
   CACHE_PERIOD: "2"
   # Increment the build number to force new conda cache upload.
@@ -29,42 +35,27 @@ env:
 # Linting
 #
 lint_task:
+  only_if: ${SKIP_LINT_TASK} == ""
   auto_cancellation: true
-  name: "Lint: flake8"
+  name: "${CIRRUS_OS}: flake8 and black"
   pip_cache:
     folder: ~/.cache/pip
     fingerprint_script:
-      - echo "${CIRRUS_OS} py${PYTHON_VERSION}"
+      - echo "${CIRRUS_TASK_NAME} py${PYTHON_VERSION}"
       - echo "$(date +%Y).$(expr $(date +%U) / ${CACHE_PERIOD}):${PIP_CACHE_BUILD} ${PIP_CACHE_PACKAGES}"
   lint_script:
     - pip list
     - python -m pip install --retries 3 --upgrade ${PIP_CACHE_PACKAGES}
     - pip list
-    - nox --session lint
-
-
-#
-# Formatting
-#
-style_task:
-  auto_cancellation: true
-  name: "Format: black"
-  pip_cache:
-    folder: ~/.cache/pip
-    fingerprint_script:
-      - echo "${CIRRUS_OS} py${PYTHON_VERSION}"
-      - echo "$(date +%Y).$(expr $(date +%U) / ${CACHE_PERIOD}):${PIP_CACHE_BUILD} ${PIP_CACHE_PACKAGES}"
-  style_script:
-    - pip list
-    - python -m pip install --retries 3 --upgrade ${PIP_CACHE_PACKAGES}
-    - pip list
-    - nox --session style
+    - nox --session flake8
+    - nox --session black
 
 
 #
 # Testing (Linux)
 #
-linux_task:
+linux_test_task:
+  only_if: ${SKIP_LINUX_TEST_TASK} == ""
   auto_cancellation: true
   matrix:
     env:
@@ -73,8 +64,8 @@ linux_task:
       PY_VER: "3.7"
     env:
       PY_VER: "3.8"
-      COVERAGE: "pytest-cov codecov"
-  name: "Linux: py${PY_VER}"
+      COVERAGE_PACKAGES: "pytest-cov codecov"
+  name: "${CIRRUS_OS}: py${PY_VER} tests"
   container:
     image: gcc:latest
   env:
@@ -102,10 +93,11 @@ linux_task:
   nox_cache:
     folder: ${CIRRUS_WORKING_DIR}/.nox
     fingerprint_script:
-      - echo "${CIRRUS_OS} tests ${PY_VER}"
+      - echo "${CIRRUS_TASK_NAME}"
       - echo "$(date +%Y).$(expr $(date +%U) / ${CACHE_PERIOD}):${NOX_CACHE_BUILD}"
-      - cat ${CIRRUS_WORKING_DIR}/requirements/py$(echo ${PY_VER} | tr -d ".").yml
-      - if [ -n "${COVERAGE}" ]; then echo "${COVERAGE}"; fi
+      - sha256sum ${CIRRUS_WORKING_DIR}/requirements/py$(echo ${PY_VER} | tr -d ".").yml
+      - if [ -n "${COVERAGE_PACKAGES}" ]; then echo "${COVERAGE_PACKAGES}"; fi
+      - if [ -n "${IRIS_SOURCE}" ]; then echo "${IRIS_SOURCE}"; fi
   test_script:
     - nox --session tests
 
@@ -113,12 +105,13 @@ linux_task:
 #
 # Testing (macOS)
 #
-osx_task:
+osx_test_task:
+  only_if: ${SKIP_OSX_TEST_TASK} == ""
   auto_cancellation: true
   matrix:
     env:
       PY_VER: "3.8"
-  name: "OSX: py${PY_VER}"
+  name: "${CIRRUS_OS}: py${PY_VER} tests"
   osx_instance:
     image: catalina-xcode
   env:
@@ -143,9 +136,10 @@ osx_task:
   nox_cache:
     folder: ${CIRRUS_WORKING_DIR}/.nox
     fingerprint_script:
-      - echo "${CIRRUS_OS} tests ${PY_VER}"
+      - echo "${CIRRUS_TASK_NAME}"
       - echo "$(date +%Y).$(expr $(date +%U) / ${CACHE_PERIOD}):${NOX_CACHE_BUILD}"
-      - cat ${CIRRUS_WORKING_DIR}/requirements/py$(echo ${PY_VER} | tr -d ".").yml
+      - shasum -a 256 ${CIRRUS_WORKING_DIR}/requirements/py$(echo ${PY_VER} | tr -d ".").yml
+      - if [ -n "${IRIS_SOURCE}" ]; then echo "${IRIS_SOURCE}"; fi
   test_script:
     - nox --session tests
 

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -5,6 +5,7 @@
 #   - https://cirrus-ci.org/guide/windows/
 #   - https://hub.docker.com/_/gcc/
 #   - https://hub.docker.com/_/python/
+#   - https://community.codecov.io/t/add-support-of-uploading-from-cirrus-ci-without-token/1028/14
 
 #
 # Global defaults.
@@ -17,8 +18,7 @@ container:
 env:
   # Skip specific tasks by name. Set to a non-empty string to skip.
   SKIP_LINT_TASK: ""
-  SKIP_LINUX_TEST_TASK: ""
-  SKIP_OSX_TEST_TASK: ""
+  SKIP_TEST_TASK: ""
   # Maximum cache period (in weeks) before forcing a new cache upload.
   CACHE_PERIOD: "2"
   # Increment the build number to force new conda cache upload.
@@ -27,8 +27,10 @@ env:
   NOX_CACHE_BUILD: "0"
   # Increment the build number to force new pip cache upload.
   PIP_CACHE_BUILD: "0"
-  # Pip package to be upgraded/installed.
-  PIP_CACHE_PACKAGES: "pip setuptools wheel nox"
+  # Pip package to be installed.
+  PIP_CACHE_PACKAGES: "pip setuptools wheel nox pyyaml"
+  # Conda packages to be installed.
+  CONDA_CACHE_PACKAGES: "nox pip pyyaml"
 
 
 #
@@ -42,7 +44,8 @@ lint_task:
     folder: ~/.cache/pip
     fingerprint_script:
       - echo "${CIRRUS_TASK_NAME} py${PYTHON_VERSION}"
-      - echo "$(date +%Y).$(expr $(date +%U) / ${CACHE_PERIOD}):${PIP_CACHE_BUILD} ${PIP_CACHE_PACKAGES}"
+      - echo "${PIP_CACHE_PACKAGES}"
+      - echo "$(date +%Y).$(expr $(date +%U) / ${CACHE_PERIOD}):${PIP_CACHE_BUILD}"
   lint_script:
     - pip list
     - python -m pip install --retries 3 --upgrade ${PIP_CACHE_PACKAGES}
@@ -54,8 +57,8 @@ lint_task:
 #
 # Testing (Linux)
 #
-linux_test_task:
-  only_if: ${SKIP_LINUX_TEST_TASK} == ""
+test_task:
+  only_if: ${SKIP_TEST_TASK} == ""
   auto_cancellation: true
   matrix:
     env:
@@ -64,20 +67,18 @@ linux_test_task:
       PY_VER: "3.7"
     env:
       PY_VER: "3.8"
-      COVERAGE_PACKAGES: "pytest-cov codecov"
+      COVERAGE: "true"
   name: "${CIRRUS_OS}: py${PY_VER} tests"
   container:
     image: gcc:latest
   env:
     PATH: ${HOME}/miniconda/bin:${PATH}
-    CODECOV_TOKEN: "ENCRYPTED\
-      [1ed538b97a8d005bdd5ab729de009ac38a2b53389edb0912\
-      d2e76f5ce1e71c5f7bdea80a79492b57af54691c8936bdc7]"
   conda_cache:
     folder: ${HOME}/miniconda
     fingerprint_script:
       - wget --quiet https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
       - echo "${CIRRUS_OS} $(sha256sum miniconda.sh)"
+      - echo "${CONDA_CACHE_PACKAGES}"
       - echo "$(date +%Y).$(expr $(date +%U) / ${CACHE_PERIOD}):${CONDA_CACHE_BUILD}"
     populate_script:
       - bash miniconda.sh -b -p ${HOME}/miniconda
@@ -85,87 +86,13 @@ linux_test_task:
       - conda config --set show_channel_urls True
       - conda config --add channels conda-forge
       - conda update --quiet --name base conda
-      - conda install --quiet --name base nox pip
-  check_script:
-    - conda info --all
-    - conda list --name base
-    - conda list --name base --explicit
+      - conda install --quiet --name base ${CONDA_CACHE_PACKAGES}
   nox_cache:
     folder: ${CIRRUS_WORKING_DIR}/.nox
     fingerprint_script:
       - echo "${CIRRUS_TASK_NAME}"
       - echo "$(date +%Y).$(expr $(date +%U) / ${CACHE_PERIOD}):${NOX_CACHE_BUILD}"
       - sha256sum ${CIRRUS_WORKING_DIR}/requirements/py$(echo ${PY_VER} | tr -d ".").yml
-      - if [ -n "${COVERAGE_PACKAGES}" ]; then echo "${COVERAGE_PACKAGES}"; fi
       - if [ -n "${IRIS_SOURCE}" ]; then echo "${IRIS_SOURCE}"; fi
   test_script:
-    - nox --session tests
-
-
-#
-# Testing (macOS)
-#
-osx_test_task:
-  only_if: ${SKIP_OSX_TEST_TASK} == ""
-  auto_cancellation: true
-  matrix:
-    env:
-      PY_VER: "3.8"
-  name: "${CIRRUS_OS}: py${PY_VER} tests"
-  osx_instance:
-    image: catalina-xcode
-  env:
-    PATH: ${HOME}/miniconda/bin:${PATH}
-  conda_cache:
-    folder: ${HOME}/miniconda
-    fingerprint_script:
-      - wget --quiet https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh -O miniconda.sh
-      - echo "${CIRRUS_OS} $(shasum -a 256 miniconda.sh)"
-      - echo "$(date +%Y).$(expr $(date +%U) / ${CACHE_PERIOD}):${CONDA_CACHE_BUILD}"
-    populate_script:
-      - bash miniconda.sh -b -p ${HOME}/miniconda
-      - conda config --set always_yes yes --set changeps1 no
-      - conda config --set show_channel_urls True
-      - conda config --add channels conda-forge
-      - conda update --quiet --name base conda
-      - conda install --quiet --name base nox pip
-  check_script:
-    - conda info --all
-    - conda list --name base
-    - conda list --name base --explicit
-  nox_cache:
-    folder: ${CIRRUS_WORKING_DIR}/.nox
-    fingerprint_script:
-      - echo "${CIRRUS_TASK_NAME}"
-      - echo "$(date +%Y).$(expr $(date +%U) / ${CACHE_PERIOD}):${NOX_CACHE_BUILD}"
-      - shasum -a 256 ${CIRRUS_WORKING_DIR}/requirements/py$(echo ${PY_VER} | tr -d ".").yml
-      - if [ -n "${IRIS_SOURCE}" ]; then echo "${IRIS_SOURCE}"; fi
-  test_script:
-    - nox --session tests
-
-
-#
-# esmpy is unavailable from conda-forge for win
-#
-# windows_task:
-#   auto_cancellation: true
-#   matrix:
-#     env:
-#       PY_VER: "3.8"
-#   name: "Windows: py${PY_VER}"
-#   windows_container:
-#     image: cirrusci/windowsservercore:2019
-#   env:
-#     ANACONDA_LOCATION: $USERPROFILE\anaconda
-#     PATH: $ANACONDA_LOCATION\Scripts;$ANACONDA_LOCATION;$PATH
-#     PYTHON_ARCH: 64
-#   install_script:
-#     - choco install -y openssl.light
-#     - choco install -y miniconda3 --params="'/D:%ANACONDA_LOCATION%'"
-#   conda_script:
-#     - conda config --set always_yes yes --set changeps1 no
-#     - conda config --set show_channel_urls True
-#     - conda config --add channels conda-forge
-#     - conda install --quiet --name base nox pip
-#   test_script:
-#     - nox --session tests
+    - nox --session tests -- --verbose

--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# Editors and IDEs
+.idea

--- a/noxfile.py
+++ b/noxfile.py
@@ -117,8 +117,12 @@ def get_iris_github_artifact(session):
         result = None
         if len(parts) == 2:
             repo, artifact = parts
+            if repo.startswith("'") or repo.startswith('"'):
+                repo = repo[1:]
             if repo.lower() == "github":
                 result = artifact
+                if result.endswith("'") or result.endswith('"'):
+                    result = result[:-1]
     return result
 
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -10,6 +10,7 @@ import os
 from pathlib import Path
 
 import nox
+import yaml
 
 
 #: Default to reusing any pre-existing nox environments.
@@ -22,38 +23,16 @@ PACKAGE = "esmf_regrid"
 PY_VER = os.environ.get("PY_VER", ["3.6", "3.7", "3.8"])
 
 #: Cirrus-CI environment variable hook.
-COVERAGE_PACKAGES = os.environ.get("COVERAGE_PACKAGES", False)
+COVERAGE = os.environ.get("COVERAGE", False)
+
+#: Cirrus-CI environment variable hook.
+IRIS_SOURCE = os.environ.get("IRIS_SOURCE", None)
+
+COVERAGE_PACKAGES = ["pytest-cov", "codecov"]
+IRIS_GITHUB = "https://github.com/scitools/iris.git"
 
 
-def venv_cached(session):
-    """
-    Determine whether the nox session environment has been cached.
-
-    Parameters
-    ----------
-    session: object
-        A `nox.sessions.Session` object.
-
-    Returns
-    -------
-    bool
-        Whether the session has been cached.
-
-    """
-    result = False
-    yml = Path(f"requirements/py{session.python.replace('.', '')}.yml")
-    tmp_dir = Path(session.create_tmp())
-    cache = tmp_dir / yml.name
-    if cache.is_file():
-        with open(yml, "rb") as fi:
-            expected = hashlib.sha256(fi.read()).hexdigest()
-        with open(cache, "r") as fi:
-            actual = fi.read()
-        result = actual == expected
-    return result
-
-
-def cache_venv(session):
+def cache_venv(session, fname):
     """
     Cache the nox session environment.
 
@@ -64,15 +43,113 @@ def cache_venv(session):
     ----------
     session: object
         A `nox.sessions.Session` object.
+    fname: str
+        Requirements filename that defines this environment.
 
     """
-    yml = Path(f"requirements/py{session.python.replace('.', '')}.yml")
-    with open(yml, "rb") as fi:
+    python_version = session.python.replace(".", "")
+    with open(fname, "rb") as fi:
         hexdigest = hashlib.sha256(fi.read()).hexdigest()
     tmp_dir = Path(session.create_tmp())
-    cache = tmp_dir / yml.name
+    cache = tmp_dir / f"py{python_version}.sha"
     with open(cache, "w") as fo:
         fo.write(hexdigest)
+
+
+def combine_requirements(primary, secondary):
+    """
+    Combine the conda environment YAML files together into one.
+
+    Parameters
+    ----------
+    primary: str
+        The filename of the primary YAML conda environment.
+    secondary: str
+        The filename of the subordinate YAML conda environment.
+
+    Returns
+    -------
+    dict
+        A dictionary of the combined YAML conda environments.
+
+    """
+    with open(primary, "r") as fi:
+        result = yaml.load(fi, Loader=yaml.FullLoader)
+    with open(secondary, "r") as fi:
+        secondary = yaml.load(fi, Loader=yaml.FullLoader)
+    # Combine the channels and dependencies only.
+    for key in ["channels", "dependencies"]:
+        result[key] = sorted(set(result[key]).union(secondary[key]))
+    # Filter out iris as a dependency as this is dealt with separately.
+    result["dependencies"] = [
+        spec for spec in result["dependencies"] if not spec.startswith("iris")
+    ]
+    return result
+
+
+def get_iris_github_artifact(session):
+    """
+    Determine whether an Iris source artifact from GitHub is required.
+
+    This can be an Iris branch name, commit sha or tag name.
+
+    Parameters
+    ----------
+    session: object
+        A `nox.sessions.Session` object.
+
+    Returns
+    -------
+    str
+        The Iris GitHub artifact.
+
+    """
+    result = IRIS_SOURCE
+    # The CLI overrides the environment variable.
+    for arg in session.posargs:
+        if arg.startswith("--iris="):
+            parts = arg.split("=")
+            if len(parts) == 2:
+                result = parts[1].strip()
+                break
+    if result:
+        parts = result.strip().split(":")
+        result = None
+        if len(parts) == 2:
+            repo, artifact = parts
+            if repo.lower() == "github":
+                result = artifact
+    return result
+
+
+def venv_cached(session, fname):
+    """
+    Determine whether the nox session environment has been cached.
+
+    Parameters
+    ----------
+    session: object
+        A `nox.sessions.Session` object.
+    fname: str
+        Requirements filename that defines this environment.
+
+    Returns
+    -------
+    bool
+        Whether the session has been cached.
+
+    """
+    result = False
+    tmp_dir = Path(session.create_tmp())
+    python_version = session.python.replace(".", "")
+    cache = tmp_dir / f"py{python_version}.sha"
+    if cache.is_file():
+        with open(fname, "rb") as fi:
+            expected = hashlib.sha256(fi.read()).hexdigest()
+        with open(cache, "r") as fi:
+            actual = fi.read()
+        result = actual == expected
+    return result
 
 
 @nox.session
@@ -130,24 +207,63 @@ def tests(session):
       - https://github.com/theacodes/nox/issues/260
 
     """
-    if not venv_cached(session):
-        # Determine the conda requirements yaml file.
-        fname = f"requirements/py{session.python.replace('.', '')}.yml"
+    artifact = get_iris_github_artifact(session)
+    python_version = session.python.replace(".", "")
+    requirements = f"requirements/py{python_version}.yml"
+
+    if artifact:
+        tmp_dir = Path(session.create_tmp())
+        artifact_dir = tmp_dir / "iris"
+        cwd = Path.cwd()
+        if not artifact_dir.is_dir():
+            session.run("git", "clone", IRIS_GITHUB, str(artifact_dir), external=True)
+        session.cd(artifact_dir)
+        session.run("git", "fetch", "origin", external=True)
+        session.run("git", "checkout", artifact, external=True)
+        session.cd(cwd)
+        iris_requirements = f"{artifact_dir}/requirements/ci/py{python_version}.yml"
+        yaml_requirements = combine_requirements(requirements, iris_requirements)
+        requirements = tmp_dir / "requirements.yml"
+        with open(requirements, "w") as fo:
+            yaml.dump(yaml_requirements, fo)
+
+    # Install the package requirements.
+    if not venv_cached(session, requirements):
         # Back-door approach to force nox to use "conda env update".
         command = (
             "conda",
             "env",
             "update",
             f"--prefix={session.virtualenv.location}",
-            f"--file={fname}",
+            f"--file={requirements}",
             "--prune",
         )
         session._run(*command, silent=True, external="error")
-        cache_venv(session)
+        cache_venv(session, requirements)
 
-    if COVERAGE_PACKAGES:
+    if artifact:
+        # Install the iris source in develop mode.
+        session.install("--no-deps", "--editable", str(artifact_dir))
+
+    # Install the esmf-regrid source in develop mode.
+    session.install("--no-deps", "--editable", ".")
+
+    # Determine whether verbose diagnostics have been requested from the command line.
+    verbose = "-v" in session.posargs or "--verbose" in session.posargs
+
+    if verbose:
+        session.run("conda", "info")
+        session.run("conda", "list", f"--prefix={session.virtualenv.location}")
+        session.run(
+            "conda",
+            "list",
+            f"--prefix={session.virtualenv.location}",
+            "--explicit",
+        )
+
+    if COVERAGE:
         # Execute the tests with code coverage.
-        session.conda_install("--channel=conda-forge", *COVERAGE_PACKAGES.split())
+        session.conda_install("--channel=conda-forge", *COVERAGE_PACKAGES)
         session.run("pytest", "--cov-report=xml", "--cov")
         session.run("codecov")
     else:

--- a/requirements/py36.yml
+++ b/requirements/py36.yml
@@ -21,6 +21,5 @@ dependencies:
   - flake8
   - flake8-docstrings
   - flake8-import-order
-  - nox
   - pre-commit
   - pytest

--- a/requirements/py37.yml
+++ b/requirements/py37.yml
@@ -21,6 +21,5 @@ dependencies:
   - flake8
   - flake8-docstrings
   - flake8-import-order
-  - nox
   - pre-commit
   - pytest

--- a/requirements/py38.yml
+++ b/requirements/py38.yml
@@ -21,6 +21,5 @@ dependencies:
   - flake8
   - flake8-docstrings
   - flake8-import-order
-  - nox
   - pre-commit
   - pytest


### PR DESCRIPTION
This PR provides `iris` source GitHub artifact support, to allow testing against a specific `iris` GitHub repo branch name, tag name or commit sha.

It also contains condidtional task execution, better caching, and controls for conda environment verbosity.

The `flake8` and `black` linting tasks have been combined, and the long/variable running `osx` task as been retired.