### PR TITLE
module level setup

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -29,5 +29,7 @@ ignore =
     # W504: line break after binary operator
     W504
 exclude = 
+    .eggs
+    build
     esmf_regrid/__init__.py
     esmf_regrid/tests/results

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: 'v2.4.0'
+    rev: 'v3.4.0'
     hooks:
         # Prevent giant files from being committed.
     -   id: check-added-large-files

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python
 
+"""iris-esmf-regrid setuptools packaging."""
+
 
 from setuptools import setup
 
 
-if __name__ == "__main__":
-    setup()
+setup()


### PR DESCRIPTION
This PR ensures that the `setup` is always executed on `import` and when run as a script.

In addition, the `pre-commit-hooks` version is updated, and additional ignores are added for `flake8`.