### PR TITLE
update greetings issue and pr message

### DIFF
--- a/.github/workflows/greetings.yml
+++ b/.github/workflows/greetings.yml
@@ -9,5 +9,5 @@ jobs:
     - uses: actions/first-interaction@v1.1.0
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
-        issue-message: '# ✨ Congratulations! ✨\nThanks for submitting your **first issue** to `iris-esmf-regrid`.\nWe really appreciate it and will get back to you as soon as possible. Awesome job 👍'
-        pr-message: '# ✨ Congratulations! ✨\nThanks for submitting your **first pull-request** to `iris-esmf-regrid`.\nWe really appreciate it and will get back to you as soon as possible. Awesome job 👍'
+        issue-message: '# ✨ Congratulations! ✨ Thanks for submitting your first issue to `iris-esmf-regrid`. We really appreciate it and will get back to you as soon as possible. Awesome job 👍'
+        pr-message: '# ✨ Congratulations! ✨ Thanks for submitting your first pull-request to `iris-esmf-regrid`. We really appreciate it and will get back to you as soon as possible. Awesome job 👍'


### PR DESCRIPTION
This PR remove `\n` escape sequences from the `greetings` messages, as they are treated literally.

<img width="1255" alt="iris-grib-issue" src="https://user-images.githubusercontent.com/2051656/110549604-3bfd5600-812a-11eb-937a-74280c756bf2.PNG">
