### PR TITLE
Unstructured Scheme - Cube Creation 2D

### DIFF
--- a/esmf_regrid/experimental/unstructured_scheme.py
+++ b/esmf_regrid/experimental/unstructured_scheme.py
@@ -1,5 +1,7 @@
 """Provides an iris interface for unstructured regridding."""
 
+import copy
+
 import iris
 from iris.analysis._interpolation import get_xy_coords
 import numpy as np
@@ -86,7 +88,13 @@ def _create_cube(data, src_cube, mesh_dim, mesh, grid_x, grid_y):
 
     new_cube = iris.cube.Cube(data)
 
-    # TODO: add coords and metadata.
+    new_cube.add_dim_coord(grid_x, mesh_dim + 1)
+    new_cube.add_dim_coord(grid_y, mesh_dim)
+
+    new_cube.metadata = copy.deepcopy(src_cube.metadata)
+
+    for coord in src_cube.coords(dimensions=()):
+        new_cube.add_aux_coord(coord.copy())
 
     return new_cube
 

--- a/esmf_regrid/experimental/unstructured_scheme.py
+++ b/esmf_regrid/experimental/unstructured_scheme.py
@@ -91,6 +91,11 @@ def _create_cube(data, src_cube, mesh_dim, grid_x, grid_y):
     # TODO: The following code assumes a 1D source cube and mesh_dim = 0.
     #  This is therefore simple code which should be updated when we start
     #  supporting the regridding of extra dimensions.
+
+    # TODO: The following code is rigid with respect to which dimensions
+    #  the x coord and y coord are assigned to. We should decide if it is
+    #  appropriate to copy the dimension ordering from the target cube
+    #  instead.
     new_cube.add_dim_coord(grid_x, mesh_dim + 1)
     new_cube.add_dim_coord(grid_y, mesh_dim)
 

--- a/esmf_regrid/experimental/unstructured_scheme.py
+++ b/esmf_regrid/experimental/unstructured_scheme.py
@@ -88,6 +88,9 @@ def _create_cube(data, src_cube, mesh_dim, grid_x, grid_y):
 
     new_cube = iris.cube.Cube(data)
 
+    # TODO: The following code assumes a 1D source cube and mesh_dim = 0.
+    #  This is therefore simple code which should be updated when we start
+    #  supporting the regridding of extra dimensions.
     new_cube.add_dim_coord(grid_x, mesh_dim + 1)
     new_cube.add_dim_coord(grid_y, mesh_dim)
 

--- a/esmf_regrid/experimental/unstructured_scheme.py
+++ b/esmf_regrid/experimental/unstructured_scheme.py
@@ -77,7 +77,7 @@ def _cube_to_GridInfo(cube):
 #     return result
 
 
-def _create_cube(data, src_cube, mesh_dim, mesh, grid_x, grid_y):
+def _create_cube(data, src_cube, mesh_dim, grid_x, grid_y):
     # Here we expect the args to be as follows:
     # data: a masked array containing the result of the regridding operation
     # src_cube: the source cube which data is regrid from
@@ -119,13 +119,13 @@ def _regrid_unstructured_to_rectilinear__prepare(src_mesh_cube, target_grid_cube
 
     regridder = Regridder(meshinfo, gridinfo)
 
-    regrid_info = (mesh, mesh_dim, grid_x, grid_y, regridder)
+    regrid_info = (mesh_dim, grid_x, grid_y, regridder)
 
     return regrid_info
 
 
 def _regrid_unstructured_to_rectilinear__perform(src_cube, regrid_info, mdtol):
-    mesh, mesh_dim, grid_x, grid_y, regridder = regrid_info
+    mesh_dim, grid_x, grid_y, regridder = regrid_info
 
     # Perform regridding with realised data for the moment. This may be changed
     # in future to handle src_cube.lazy_data.
@@ -137,7 +137,6 @@ def _regrid_unstructured_to_rectilinear__perform(src_cube, regrid_info, mdtol):
         new_data,
         src_cube,
         mesh_dim,
-        mesh,
         grid_x,
         grid_y,
     )

--- a/esmf_regrid/tests/unit/experimental/unstructured_scheme/test__create_cube.py
+++ b/esmf_regrid/tests/unit/experimental/unstructured_scheme/test__create_cube.py
@@ -29,8 +29,11 @@ def test_create_cube_2D():
 
     cube = _create_cube(data, src_cube, mesh_dim, mesh, grid_x, grid_y)
     src_metadata = src_cube.metadata
-    src_scalars = src_cube.coords(dimensions=())
-    assert src_metadata == cube.metadata
-    assert src_scalars == cube.coords(dimensions=())
-    assert cube.coord_dims(grid_x) == (1,)
-    assert cube.coord_dims(grid_y) == (0,)
+
+    expected_cube = iris.cube.Cube(data)
+    expected_cube.metadata = src_metadata
+    expected_cube.add_dim_coord(grid_x, 1)
+    expected_cube.add_dim_coord(grid_y, 0)
+    expected_cube.add_aux_coord(scalar_height)
+    expected_cube.add_aux_coord(scalar_time)
+    assert expected_cube == cube

--- a/esmf_regrid/tests/unit/experimental/unstructured_scheme/test__create_cube.py
+++ b/esmf_regrid/tests/unit/experimental/unstructured_scheme/test__create_cube.py
@@ -21,13 +21,11 @@ def test_create_cube_2D():
     src_cube.add_aux_coord(scalar_time)
 
     mesh_dim = 0
-    # TODO: replace this with an actual mesh.
-    mesh = None
 
     grid_x = iris.coords.DimCoord(np.arange(3), standard_name="longitude")
     grid_y = iris.coords.DimCoord(np.arange(2), standard_name="latitude")
 
-    cube = _create_cube(data, src_cube, mesh_dim, mesh, grid_x, grid_y)
+    cube = _create_cube(data, src_cube, mesh_dim, grid_x, grid_y)
     src_metadata = src_cube.metadata
 
     expected_cube = iris.cube.Cube(data)

--- a/esmf_regrid/tests/unit/experimental/unstructured_scheme/test__create_cube.py
+++ b/esmf_regrid/tests/unit/experimental/unstructured_scheme/test__create_cube.py
@@ -1,12 +1,13 @@
 """Unit tests for miscellaneous helper functions in `esmf_regrid.experimental.unstructured_scheme`."""
 
-import numpy as np
 import iris
+import numpy as np
 
 from esmf_regrid.experimental.unstructured_scheme import _create_cube
 
+
 def test_create_cube_2D():
-    """test creation of 2D output grid"""
+    """Test creation of 2D output grid."""
     data = np.ones([2, 3])
 
     # Create a source cube with metadata and scalar coords

--- a/esmf_regrid/tests/unit/experimental/unstructured_scheme/test__create_cube.py
+++ b/esmf_regrid/tests/unit/experimental/unstructured_scheme/test__create_cube.py
@@ -1,0 +1,35 @@
+"""Unit tests for miscellaneous helper functions in `esmf_regrid.experimental.unstructured_scheme`."""
+
+import numpy as np
+import iris
+
+from esmf_regrid.experimental.unstructured_scheme import _create_cube
+
+def test_create_cube_2D():
+    """test creation of 2D output grid"""
+    data = np.ones([2, 3])
+
+    # Create a source cube with metadata and scalar coords
+    src_cube = iris.cube.Cube(np.zeros(5))
+    src_cube.units = "K"
+    src_cube.attributes = {"a": 1}
+    src_cube.standard_name = "air_temperature"
+    scalar_height = iris.coords.AuxCoord([5], units="m", standard_name="height")
+    scalar_time = iris.coords.DimCoord([10], units="s", standard_name="time")
+    src_cube.add_aux_coord(scalar_height)
+    src_cube.add_aux_coord(scalar_time)
+
+    mesh_dim = 0
+    # TODO: replace this with an actual mesh.
+    mesh = None
+
+    grid_x = iris.coords.DimCoord(np.arange(3), standard_name="longitude")
+    grid_y = iris.coords.DimCoord(np.arange(2), standard_name="latitude")
+
+    cube = _create_cube(data, src_cube, mesh_dim, mesh, grid_x, grid_y)
+    src_metadata = src_cube.metadata
+    src_scalars = src_cube.coords(dimensions=())
+    assert src_metadata == cube.metadata
+    assert src_scalars == cube.coords(dimensions=())
+    assert cube.coord_dims(grid_x) == (1,)
+    assert cube.coord_dims(grid_y) == (0,)


### PR DESCRIPTION
Fleshes out the creation of cubes. Now adds grid coordinates from the target cube and copies over metadata and scalar coords from the source cube. Code is mostly copied from a similar iris functionality here https://github.com/SciTools/iris/blob/master/lib/iris/analysis/_regrid.py#L360-L363.