### PR TITLE
update pre-commit flake8 version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,7 +24,7 @@ repos:
         pass_filenames: false
         args: [--config=./pyproject.toml, .]
 -   repo: https://gitlab.com/pycqa/flake8
-    rev: '3.8.4'
+    rev: '3.9.0'
     hooks:
         # Run flake8.
     -   id: flake8


### PR DESCRIPTION
This PR updates the `flake8` pre-commit hook version