### PR TITLE
Unstructured Scheme - Mesh Fetching

### DIFF
--- a/esmf_regrid/experimental/unstructured_scheme.py
+++ b/esmf_regrid/experimental/unstructured_scheme.py
@@ -176,7 +176,7 @@ class MeshToGridESMFRegridder:
         )
 
         # Store regrid info.
-        _, _, self.grid_x, self.grid_y, self.regridder = partial_regrid_info
+        _, self.grid_x, self.grid_y, self.regridder = partial_regrid_info
 
     def __call__(self, cube):
         """TODO: write docstring."""

--- a/esmf_regrid/experimental/unstructured_scheme.py
+++ b/esmf_regrid/experimental/unstructured_scheme.py
@@ -110,6 +110,8 @@ def _regrid_unstructured_to_rectilinear__prepare(src_mesh_cube, target_grid_cube
 
     grid_x, grid_y = get_xy_dim_coords(target_grid_cube)
     mesh = src_mesh_cube.mesh
+    # TODO: Improve the checking of mesh validity. Check the mesh location and
+    #  raise appropriate error messages.
     assert mesh is not None
     # From src_mesh_cube, fetch the mesh, and the dimension on the cube which that
     # mesh belongs to.
@@ -180,9 +182,9 @@ class MeshToGridESMFRegridder:
 
     def __call__(self, cube):
         """TODO: write docstring."""
-        # TODO: Ensure cube has the same mesh as that of the recorded mesh.
-
         mesh = cube.mesh
+        # TODO: Ensure cube has the same mesh as that of the recorded mesh.
+        #  For the time being, we simply check that the mesh exists.
         assert mesh is not None
         mesh_dim = cube.mesh_dim()
 

--- a/esmf_regrid/experimental/unstructured_scheme.py
+++ b/esmf_regrid/experimental/unstructured_scheme.py
@@ -3,7 +3,7 @@
 import copy
 
 import iris
-from iris.analysis._interpolation import get_xy_coords
+from iris.analysis._interpolation import get_xy_dim_coords
 import numpy as np
 
 # from numpy import ma
@@ -19,15 +19,6 @@ def _bounds_cf_to_simple_1d(cf_bounds):
     simple_bounds[:-1] = cf_bounds[:, 0]
     simple_bounds[-1] = cf_bounds[-1, 1]
     return simple_bounds
-
-
-def _get_mesh_and_dim(cube):
-    # Returns the cube's mesh and the dimension that mesh belongs to.
-    # Likely to be of the form:
-    # mesh = cube.mesh
-    # mesh_dim = cube.mesh_dim(mesh)
-    # return mesh, mesh_dim
-    pass
 
 
 def _mesh_to_MeshInfo(mesh):
@@ -117,10 +108,12 @@ def _regrid_unstructured_to_rectilinear__prepare(src_mesh_cube, target_grid_cube
 
     # TODO: Record appropriate dimensions (i.e. which dimension the mesh belongs to)
 
-    grid_x, grid_y = get_xy_coords(target_grid_cube)
+    grid_x, grid_y = get_xy_dim_coords(target_grid_cube)
+    mesh = src_mesh_cube.mesh
+    assert mesh is not None
     # From src_mesh_cube, fetch the mesh, and the dimension on the cube which that
-    # mesh belongs to (mesh_dim).
-    mesh, mesh_dim = _get_mesh_and_dim(src_mesh_cube)
+    # mesh belongs to.
+    mesh_dim = src_mesh_cube.mesh_dim()
 
     meshinfo = _mesh_to_MeshInfo(mesh)
     gridinfo = _cube_to_GridInfo(target_grid_cube)
@@ -189,8 +182,9 @@ class MeshToGridESMFRegridder:
         """TODO: write docstring."""
         # TODO: Ensure cube has the same mesh as that of the recorded mesh.
 
-        # mesh is probably an iris Mesh object, though it could also be a MeshCoord
-        mesh, mesh_dim = _get_mesh_and_dim(cube)
+        mesh = cube.mesh
+        assert mesh is not None
+        mesh_dim = cube.mesh_dim()
 
         regrid_info = (mesh, mesh_dim, self.grid_x, self.grid_y, self.regridder)
 

--- a/esmf_regrid/experimental/unstructured_scheme.py
+++ b/esmf_regrid/experimental/unstructured_scheme.py
@@ -186,7 +186,7 @@ class MeshToGridESMFRegridder:
         assert mesh is not None
         mesh_dim = cube.mesh_dim()
 
-        regrid_info = (mesh, mesh_dim, self.grid_x, self.grid_y, self.regridder)
+        regrid_info = (mesh_dim, self.grid_x, self.grid_y, self.regridder)
 
         return _regrid_unstructured_to_rectilinear__perform(
             cube, regrid_info, self.mdtol

--- a/esmf_regrid/tests/unit/experimental/unstructured_scheme/__init__.py
+++ b/esmf_regrid/tests/unit/experimental/unstructured_scheme/__init__.py
@@ -1,0 +1,1 @@
+"""Unit tests for :mod:`esmf_regrid.experimental.unstructured_scheme`."""

--- a/esmf_regrid/tests/unit/experimental/unstructured_scheme/test_MeshToGridESMFRegridder.py
+++ b/esmf_regrid/tests/unit/experimental/unstructured_scheme/test_MeshToGridESMFRegridder.py
@@ -1,11 +1,11 @@
-"""Unit tests for :func:`esmf_regrid.experimental.unstructured_scheme.regrid_unstructured_to_rectilinear`."""
+"""Unit tests for :func:`esmf_regrid.experimental.unstructured_scheme.MeshToGridESMFRegridder`."""
 
 from iris.coords import AuxCoord, DimCoord
 from iris.cube import Cube
 import numpy as np
 
 from esmf_regrid.experimental.unstructured_scheme import (
-    regrid_unstructured_to_rectilinear,
+    MeshToGridESMFRegridder,
 )
 from esmf_regrid.tests.unit.experimental.unstructured_scheme.test__cube_to_GridInfo import (
     _grid_cube,
@@ -17,7 +17,7 @@ from esmf_regrid.tests.unit.experimental.unstructured_scheme.test__regrid_unstru
 
 def test_flat_cubes():
     """
-    Basic test for :func:`esmf_regrid.experimental.unstructured_scheme.regrid_unstructured_to_rectilinear`.
+    Basic test for :func:`esmf_regrid.experimental.unstructured_scheme.MeshToGridESMFRegridder`.
 
     Tests with flat cubes as input (a 1D mesh cube and a 2D grid cube).
     """
@@ -42,7 +42,8 @@ def test_flat_cubes():
         return result
 
     src = _add_metadata(src)
-    result = regrid_unstructured_to_rectilinear(src, tgt)
+    regridder = MeshToGridESMFRegridder(src, tgt)
+    result = regridder(src)
 
     expected_data = np.ones([5, 6])
     expected_cube = _add_metadata(tgt)

--- a/esmf_regrid/tests/unit/experimental/unstructured_scheme/test_MeshToGridESMFRegridder.py
+++ b/esmf_regrid/tests/unit/experimental/unstructured_scheme/test_MeshToGridESMFRegridder.py
@@ -1,7 +1,6 @@
 """Unit tests for :func:`esmf_regrid.experimental.unstructured_scheme.MeshToGridESMFRegridder`."""
 
 from iris.coords import AuxCoord, DimCoord
-from iris.cube import Cube
 import numpy as np
 
 from esmf_regrid.experimental.unstructured_scheme import (

--- a/esmf_regrid/tests/unit/experimental/unstructured_scheme/test_MeshToGridESMFRegridder.py
+++ b/esmf_regrid/tests/unit/experimental/unstructured_scheme/test_MeshToGridESMFRegridder.py
@@ -27,6 +27,8 @@ def test_flat_cubes():
     lon_bounds = (-180, 180)
     lat_bounds = (-90, 90)
     tgt = _grid_cube(n_lons, n_lats, lon_bounds, lat_bounds, circular=True)
+    # Ensure data in the target grid is different to the expected data.
+    # i.e. target grid data is all zero, expected data is all one
     tgt.data[:] = 0
 
     def _add_metadata(cube):
@@ -41,10 +43,11 @@ def test_flat_cubes():
         return result
 
     src = _add_metadata(src)
+    src.data[:] = 1  # Ensure all data in the source is one.
     regridder = MeshToGridESMFRegridder(src, tgt)
     result = regridder(src)
 
-    expected_data = np.ones([5, 6])
+    expected_data = np.ones([n_lats, n_lons])
     expected_cube = _add_metadata(tgt)
 
     # Lenient check for data.

--- a/esmf_regrid/tests/unit/experimental/unstructured_scheme/test__regrid_unstructured_to_rectilinear__prepare.py
+++ b/esmf_regrid/tests/unit/experimental/unstructured_scheme/test__regrid_unstructured_to_rectilinear__prepare.py
@@ -9,8 +9,8 @@ from esmf_regrid.experimental.unstructured_regrid import MeshInfo
 from esmf_regrid.experimental.unstructured_scheme import (
     _regrid_unstructured_to_rectilinear__prepare,
 )
-from test__cube_to_GridInfo import _grid_cube
-from test__mesh_to_MeshInfo import _example_mesh
+from esmf_regrid.tests.unit.experimental.unstructured_scheme.test__cube_to_GridInfo import _grid_cube
+from esmf_regrid.tests.unit.experimental.unstructured_scheme.test__mesh_to_MeshInfo import _example_mesh
 
 
 def _full_mesh():

--- a/esmf_regrid/tests/unit/experimental/unstructured_scheme/test__regrid_unstructured_to_rectilinear__prepare.py
+++ b/esmf_regrid/tests/unit/experimental/unstructured_scheme/test__regrid_unstructured_to_rectilinear__prepare.py
@@ -1,0 +1,53 @@
+"""Unit tests for :func:`esmf_regrid.experimental.unstructured_scheme._regrid_unstructured_to_rectilinear__prepare`."""
+
+from iris.coords import AuxCoord
+from iris.cube import Cube
+import numpy as np
+
+from esmf_regrid.esmf_regridder import GridInfo
+from esmf_regrid.experimental.unstructured_regrid import MeshInfo
+from esmf_regrid.experimental.unstructured_scheme import (
+    _regrid_unstructured_to_rectilinear__prepare,
+)
+from test__cube_to_GridInfo import _grid_cube
+from test__mesh_to_MeshInfo import _example_mesh
+
+
+def _full_mesh():
+    mesh = _example_mesh()
+
+    mesh_length = mesh.connectivity(contains_face=True).shape[0]
+    dummy_face_lon = AuxCoord(np.zeros(mesh_length), standard_name="longitude")
+    dummy_face_lat = AuxCoord(np.zeros(mesh_length), standard_name="latitude")
+    mesh.add_coords(face_x=dummy_face_lon, face_y=dummy_face_lat)
+    mesh.long_name = "example mesh"
+    return mesh
+
+
+def _flat_mesh_cube():
+    mesh = _full_mesh()
+    mesh_length = mesh.connectivity(contains_face=True).shape[0]
+
+    cube = Cube(np.ones([mesh_length]))
+    mesh_coord_x, mesh_coord_y = mesh.to_MeshCoords("face")
+    cube.add_aux_coord(mesh_coord_x, 0)
+    cube.add_aux_coord(mesh_coord_y, 0)
+    return cube
+
+
+def test_flat_cubes():
+    src = _flat_mesh_cube()
+
+    n_lons = 6
+    n_lats = 5
+    lon_bounds = (-180, 180)
+    lat_bounds = (-90, 90)
+    tgt = _grid_cube(n_lons, n_lats, lon_bounds, lat_bounds, circular=True)
+    regrid_info = _regrid_unstructured_to_rectilinear__prepare(src, tgt)
+    mesh_dim, grid_x, grid_y, regridder = regrid_info
+
+    assert mesh_dim == 0
+    assert grid_x == tgt.coord("longitude")
+    assert grid_y == tgt.coord("latitude")
+    assert type(regridder.tgt) == GridInfo
+    assert type(regridder.src) == MeshInfo

--- a/esmf_regrid/tests/unit/experimental/unstructured_scheme/test__regrid_unstructured_to_rectilinear__prepare.py
+++ b/esmf_regrid/tests/unit/experimental/unstructured_scheme/test__regrid_unstructured_to_rectilinear__prepare.py
@@ -36,6 +36,11 @@ def _flat_mesh_cube():
 
 
 def test_flat_cubes():
+    """
+    Basic test for :func:`esmf_regrid.experimental.unstructured_scheme._regrid_unstructured_to_rectilinear__prepare`.
+    
+    Tests with flat cubes as input (a 1D mesh cube and a 2D grid cube).
+    """
     src = _flat_mesh_cube()
 
     n_lons = 6

--- a/esmf_regrid/tests/unit/experimental/unstructured_scheme/test__regrid_unstructured_to_rectilinear__prepare.py
+++ b/esmf_regrid/tests/unit/experimental/unstructured_scheme/test__regrid_unstructured_to_rectilinear__prepare.py
@@ -31,7 +31,12 @@ def _full_mesh():
 
 
 def _flat_mesh_cube():
-    """Return a 1D cube with a mesh attached."""
+    """
+    Return a 1D cube with a mesh attached.
+
+    Returned cube has no metadata except for the mesh and two MeshCoords.
+    Returned cube has data consisting of an array of ones.
+    """
     mesh = _full_mesh()
     mesh_length = mesh.connectivity(contains_face=True).shape[0]
 

--- a/esmf_regrid/tests/unit/experimental/unstructured_scheme/test__regrid_unstructured_to_rectilinear__prepare.py
+++ b/esmf_regrid/tests/unit/experimental/unstructured_scheme/test__regrid_unstructured_to_rectilinear__prepare.py
@@ -20,6 +20,8 @@ from esmf_regrid.tests.unit.experimental.unstructured_scheme.test__mesh_to_MeshI
 def _full_mesh():
     mesh = _example_mesh()
 
+    # In order to add a mesh to a cube, face locations must be added.
+    # These are not used in calculations and are here given a value of zero.
     mesh_length = mesh.connectivity(contains_face=True).shape[0]
     dummy_face_lon = AuxCoord(np.zeros(mesh_length), standard_name="longitude")
     dummy_face_lat = AuxCoord(np.zeros(mesh_length), standard_name="latitude")
@@ -29,6 +31,7 @@ def _full_mesh():
 
 
 def _flat_mesh_cube():
+    """Return a 1D cube with a mesh attached."""
     mesh = _full_mesh()
     mesh_length = mesh.connectivity(contains_face=True).shape[0]
 
@@ -42,7 +45,7 @@ def _flat_mesh_cube():
 def test_flat_cubes():
     """
     Basic test for :func:`esmf_regrid.experimental.unstructured_scheme._regrid_unstructured_to_rectilinear__prepare`.
-    
+
     Tests with flat cubes as input (a 1D mesh cube and a 2D grid cube).
     """
     src = _flat_mesh_cube()

--- a/esmf_regrid/tests/unit/experimental/unstructured_scheme/test_regrid_unstructured_to_rectilinear.py
+++ b/esmf_regrid/tests/unit/experimental/unstructured_scheme/test_regrid_unstructured_to_rectilinear.py
@@ -43,10 +43,10 @@ def test_flat_cubes():
         return result
 
     src = _add_metadata(src)
+    src.data[:] = 1  # Ensure all data in the source is one.
     result = regrid_unstructured_to_rectilinear(src, tgt)
 
     expected_data = np.ones([n_lats, n_lons])
-    src.data[:] = 1  # Ensure all data in the source is one.
     expected_cube = _add_metadata(tgt)
 
     # Lenient check for data.

--- a/esmf_regrid/tests/unit/experimental/unstructured_scheme/test_regrid_unstructured_to_rectilinear.py
+++ b/esmf_regrid/tests/unit/experimental/unstructured_scheme/test_regrid_unstructured_to_rectilinear.py
@@ -27,6 +27,8 @@ def test_flat_cubes():
     lon_bounds = (-180, 180)
     lat_bounds = (-90, 90)
     tgt = _grid_cube(n_lons, n_lats, lon_bounds, lat_bounds, circular=True)
+    # Ensure data in the target grid is different to the expected data.
+    # i.e. target grid data is all zero, expected data is all one
     tgt.data[:] = 0
 
     def _add_metadata(cube):
@@ -43,7 +45,8 @@ def test_flat_cubes():
     src = _add_metadata(src)
     result = regrid_unstructured_to_rectilinear(src, tgt)
 
-    expected_data = np.ones([5, 6])
+    expected_data = np.ones([n_lats, n_lons])
+    src.data[:] = 1  # Ensure all data in the source is one.
     expected_cube = _add_metadata(tgt)
 
     # Lenient check for data.

--- a/esmf_regrid/tests/unit/experimental/unstructured_scheme/test_regrid_unstructured_to_rectilinear.py
+++ b/esmf_regrid/tests/unit/experimental/unstructured_scheme/test_regrid_unstructured_to_rectilinear.py
@@ -1,0 +1,68 @@
+"""Unit tests for :func:`esmf_regrid.experimental.unstructured_scheme._regrid_unstructured_to_rectilinear__prepare`."""
+
+from iris.coords import AuxCoord, DimCoord
+from iris.cube import Cube
+import numpy as np
+
+from esmf_regrid.experimental.unstructured_scheme import (
+    regrid_unstructured_to_rectilinear,
+)
+from test__cube_to_GridInfo import _grid_cube
+from test__mesh_to_MeshInfo import _example_mesh
+
+
+def _full_mesh():
+    mesh = _example_mesh()
+
+    mesh_length = mesh.connectivity(contains_face=True).shape[0]
+    dummy_face_lon = AuxCoord(np.zeros(mesh_length), standard_name="longitude")
+    dummy_face_lat = AuxCoord(np.zeros(mesh_length), standard_name="latitude")
+    mesh.add_coords(face_x=dummy_face_lon, face_y=dummy_face_lat)
+    mesh.long_name = "example mesh"
+    return mesh
+
+
+def _flat_mesh_cube():
+    mesh = _full_mesh()
+    mesh_length = mesh.connectivity(contains_face=True).shape[0]
+
+    cube = Cube(np.ones([mesh_length]))
+    mesh_coord_x, mesh_coord_y = mesh.to_MeshCoords("face")
+    cube.add_aux_coord(mesh_coord_x, 0)
+    cube.add_aux_coord(mesh_coord_y, 0)
+    return cube
+
+
+def test_flat_cubes():
+    src = _flat_mesh_cube()
+
+    n_lons = 6
+    n_lats = 5
+    lon_bounds = (-180, 180)
+    lat_bounds = (-90, 90)
+    tgt = _grid_cube(n_lons, n_lats, lon_bounds, lat_bounds, circular=True)
+    tgt.data[:] = 0
+
+    def _add_metadata(cube):
+        result = cube.copy()
+        result.units = "K"
+        result.attributes = {"a": 1}
+        result.standard_name = "air_temperature"
+        scalar_height = AuxCoord([5], units="m", standard_name="height")
+        scalar_time = DimCoord([10], units="s", standard_name="time")
+        result.add_aux_coord(scalar_height)
+        result.add_aux_coord(scalar_time)
+        return result
+
+    src = _add_metadata(src)
+    result = regrid_unstructured_to_rectilinear(src, tgt)
+
+    expected_data = np.ones([5, 6])
+    expected_cube = _add_metadata(tgt)
+
+    # Lenient check for data.
+    assert np.allclose(expected_data, result.data)
+
+    # Check metadata and scalar coords.
+    expected_cube.data = result.data
+    assert expected_cube == result

--- a/esmf_regrid/tests/unit/experimental/unstructured_scheme/test_regrid_unstructured_to_rectilinear.py
+++ b/esmf_regrid/tests/unit/experimental/unstructured_scheme/test_regrid_unstructured_to_rectilinear.py
@@ -1,7 +1,6 @@
 """Unit tests for :func:`esmf_regrid.experimental.unstructured_scheme.regrid_unstructured_to_rectilinear`."""
 
 from iris.coords import AuxCoord, DimCoord
-from iris.cube import Cube
 import numpy as np
 
 from esmf_regrid.experimental.unstructured_scheme import (

--- a/esmf_regrid/tests/unit/experimental/unstructured_scheme/test_regrid_unstructured_to_rectilinear.py
+++ b/esmf_regrid/tests/unit/experimental/unstructured_scheme/test_regrid_unstructured_to_rectilinear.py
@@ -1,4 +1,4 @@
-"""Unit tests for :func:`esmf_regrid.experimental.unstructured_scheme._regrid_unstructured_to_rectilinear__prepare`."""
+"""Unit tests for :func:`esmf_regrid.experimental.unstructured_scheme.regrid_unstructured_to_rectilinear`."""
 
 from iris.coords import AuxCoord, DimCoord
 from iris.cube import Cube

--- a/esmf_regrid/tests/unit/experimental/unstructured_scheme/test_regrid_unstructured_to_rectilinear.py
+++ b/esmf_regrid/tests/unit/experimental/unstructured_scheme/test_regrid_unstructured_to_rectilinear.py
@@ -7,8 +7,8 @@ import numpy as np
 from esmf_regrid.experimental.unstructured_scheme import (
     regrid_unstructured_to_rectilinear,
 )
-from test__cube_to_GridInfo import _grid_cube
-from test__mesh_to_MeshInfo import _example_mesh
+from esmf_regrid.tests.unit.experimental.unstructured_scheme.test__cube_to_GridInfo import _grid_cube
+from esmf_regrid.tests.unit.experimental.unstructured_scheme.test__mesh_to_MeshInfo import _example_mesh
 
 
 def _full_mesh():

--- a/esmf_regrid/tests/unit/experimental/unstructured_scheme/test_regrid_unstructured_to_rectilinear.py
+++ b/esmf_regrid/tests/unit/experimental/unstructured_scheme/test_regrid_unstructured_to_rectilinear.py
@@ -34,6 +34,11 @@ def _flat_mesh_cube():
 
 
 def test_flat_cubes():
+    """
+    Basic test for :func:`esmf_regrid.experimental.unstructured_scheme.regrid_unstructured_to_rectilinear`.
+
+    Tests with flat cubes as input (a 1D mesh cube and a 2D grid cube).
+    """
     src = _flat_mesh_cube()
 
     n_lons = 6


### PR DESCRIPTION
This PR adds support for fetching meshes and mesh dimensions from iris. Originally we had planned on using a helper function `_get_mesh_and_dim` to do this, however iris has updated to the point where this functionality is given in one line, so for clarities sake I have replaced the helper function. Instead of testing the helper function, I have tested `_regrid_unstructured_to_rectilinear__prepare`, where `_get_mesh_and_dim` would have been called. I have also added a test for `regrid_unstructured_to_rectilinear` to show that the whole regridder now functions as a result. Full test coverage can be added in a further PR.