### PR TITLE
update conda cache fingerprint

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -79,6 +79,7 @@ test_task:
       - echo "${CIRRUS_OS} $(sha256sum miniconda.sh)"
       - echo "${CONDA_CACHE_PACKAGES}"
       - echo "$(date +%Y).$(expr $(date +%U) / ${CACHE_PERIOD}):${CONDA_CACHE_BUILD}"
+      - uname -r
     populate_script:
       - export CONDA_OVERRIDE_LINUX="$(uname -r | cut -d'+' -f1)"
       - bash miniconda.sh -b -p ${HOME}/miniconda


### PR DESCRIPTION
Just to cover ourselves, let's add the `uname -r` to the conda cache fingerprint