### PR TITLE
Unstructured Scheme - Extra Dims

### DIFF
--- a/esmf_regrid/experimental/unstructured_scheme.py
+++ b/esmf_regrid/experimental/unstructured_scheme.py
@@ -5,7 +5,6 @@ import copy
 import iris
 from iris.analysis._interpolation import get_xy_dim_coords
 import numpy as np
-from numpy import ma
 
 from esmf_regrid.esmf_regridder import GridInfo, Regridder
 from esmf_regrid.experimental.unstructured_regrid import MeshInfo

--- a/esmf_regrid/experimental/unstructured_scheme.py
+++ b/esmf_regrid/experimental/unstructured_scheme.py
@@ -63,8 +63,7 @@ def _regrid_along_dims(regridder, data, src_dim, mdtol):
     result = regridder.regrid(data, mdtol=mdtol)
 
     # Move grid axes back into the original position of the mesh.
-    result = np.moveaxis(result, -1, src_dim)
-    result = np.moveaxis(result, -1, src_dim)
+    result = np.moveaxis(result, [-2, -1], [src_dim, src_dim + 1])
 
     return result
 

--- a/esmf_regrid/experimental/unstructured_scheme.py
+++ b/esmf_regrid/experimental/unstructured_scheme.py
@@ -57,17 +57,15 @@ def _cube_to_GridInfo(cube):
 def _regrid_along_dims(regridder, data, src_dim, mdtol):
     # Before regridding, data is transposed to a standard form.
     # In the future, this may be done within the regridder by specifying args.
-    data_dims = len(data.shape)
-    new_axes_in = list(range(data_dims))
-    new_axes_in.pop(src_dim)
-    new_axes_in.append(src_dim)
-    data = ma.transpose(data, axes=new_axes_in)
+
+    # Move the mesh axis to be the last dimension.
+    data = np.moveaxis(data, src_dim, -1)
 
     result = regridder.regrid(data, mdtol=mdtol)
-    new_axes_out = list(range(data_dims - 1))
-    new_axes_out.insert(src_dim, data_dims - 1)
-    new_axes_out.insert(src_dim + 1, data_dims)
-    result = ma.transpose(result, axes=new_axes_out)
+
+    # Move grid axes back into the original position of the mesh.
+    result = np.moveaxis(result, -1, src_dim)
+    result = np.moveaxis(result, -1, src_dim)
 
     return result
 

--- a/esmf_regrid/experimental/unstructured_scheme.py
+++ b/esmf_regrid/experimental/unstructured_scheme.py
@@ -56,8 +56,7 @@ def _cube_to_GridInfo(cube):
 
 def _regrid_along_dims(regridder, data, src_dim, mdtol):
     # Before regridding, data is transposed to a standard form.
-    # This will be done either with something like the following code
-    # or else done within the regridder by specifying args.
+    # In the future, this may be done within the regridder by specifying args.
     data_dims = len(data.shape)
     new_axes_in = list(range(data_dims))
     new_axes_in.pop(src_dim)

--- a/esmf_regrid/experimental/unstructured_scheme.py
+++ b/esmf_regrid/experimental/unstructured_scheme.py
@@ -53,17 +53,17 @@ def _cube_to_GridInfo(cube):
     )
 
 
-def _regrid_along_dims(regridder, data, src_dim, mdtol):
+def _regrid_along_mesh_dim(regridder, data, mesh_dim, mdtol):
     # Before regridding, data is transposed to a standard form.
     # In the future, this may be done within the regridder by specifying args.
 
     # Move the mesh axis to be the last dimension.
-    data = np.moveaxis(data, src_dim, -1)
+    data = np.moveaxis(data, mesh_dim, -1)
 
     result = regridder.regrid(data, mdtol=mdtol)
 
     # Move grid axes back into the original position of the mesh.
-    result = np.moveaxis(result, [-2, -1], [src_dim, src_dim + 1])
+    result = np.moveaxis(result, [-2, -1], [mesh_dim, mesh_dim + 1])
 
     return result
 
@@ -194,7 +194,7 @@ def _regrid_unstructured_to_rectilinear__perform(src_cube, regrid_info, mdtol):
 
     # Perform regridding with realised data for the moment. This may be changed
     # in future to handle src_cube.lazy_data.
-    new_data = _regrid_along_dims(regridder, src_cube.data, mesh_dim, mdtol)
+    new_data = _regrid_along_mesh_dim(regridder, src_cube.data, mesh_dim, mdtol)
 
     new_cube = _create_cube(
         new_data,

--- a/esmf_regrid/experimental/unstructured_scheme.py
+++ b/esmf_regrid/experimental/unstructured_scheme.py
@@ -5,8 +5,7 @@ import copy
 import iris
 from iris.analysis._interpolation import get_xy_dim_coords
 import numpy as np
-
-# from numpy import ma
+from numpy import ma
 
 from esmf_regrid.esmf_regridder import GridInfo, Regridder
 from esmf_regrid.experimental.unstructured_regrid import MeshInfo
@@ -55,17 +54,23 @@ def _cube_to_GridInfo(cube):
     )
 
 
-# def _regrid_along_dims(regridder, data, src_dim, mdtol):
-#     # Before regridding, data is transposed to a standard form.
-#     # This will be done either with something like the following code
-#     # or else done within the regridder by specifying args.
-#     # new_axes = list(range(len(data.shape)))
-#     # new_axes.pop(src_dim)
-#     # new_axes.append(src_dim)
-#     # data = ma.transpose(data, axes=new_axes)
-#
-#     result = regridder.regrid(data, mdtol=mdtol)
-#     return result
+def _regrid_along_dims(regridder, data, src_dim, mdtol):
+    # Before regridding, data is transposed to a standard form.
+    # This will be done either with something like the following code
+    # or else done within the regridder by specifying args.
+    data_dims = len(data.shape)
+    new_axes_in = list(range(data_dims))
+    new_axes_in.pop(src_dim)
+    new_axes_in.append(src_dim)
+    data = ma.transpose(data, axes=new_axes_in)
+
+    result = regridder.regrid(data, mdtol=mdtol)
+    new_axes_out = list(range(data_dims - 1))
+    new_axes_out.insert(src_dim, data_dims - 1)
+    new_axes_out.insert(src_dim + 1, data_dims)
+    result = ma.transpose(result, axes=new_axes_out)
+
+    return result
 
 
 def _create_cube(data, src_cube, mesh_dim, grid_x, grid_y):
@@ -194,9 +199,7 @@ def _regrid_unstructured_to_rectilinear__perform(src_cube, regrid_info, mdtol):
 
     # Perform regridding with realised data for the moment. This may be changed
     # in future to handle src_cube.lazy_data.
-    new_data = regridder.regrid(src_cube.data, mdtol=mdtol)
-    # When we want to handle extra dimensions, we may want to do something like:
-    # new_data = _regrid_along_dims(src_cube.data, mesh_dim, mdtol)
+    new_data = _regrid_along_dims(regridder, src_cube.data, mesh_dim, mdtol)
 
     new_cube = _create_cube(
         new_data,

--- a/esmf_regrid/tests/unit/experimental/unstructured_scheme/test_MeshToGridESMFRegridder.py
+++ b/esmf_regrid/tests/unit/experimental/unstructured_scheme/test_MeshToGridESMFRegridder.py
@@ -76,7 +76,8 @@ def test_multidim_cubes():
     height = DimCoord(np.arange(h), standard_name="height")
     time = DimCoord(np.arange(t), standard_name="time")
 
-    mesh_cube = Cube(np.zeros([t, mesh_length, h]))
+    src_data = np.empty([t, mesh_length, h])
+    src_data[:] = np.arange(t * h).reshape([t, h])[:, np.newaxis, :]
     mesh_coord_x, mesh_coord_y = mesh.to_MeshCoords("face")
     mesh_cube.add_aux_coord(mesh_coord_x, 1)
     mesh_cube.add_aux_coord(mesh_coord_y, 1)
@@ -95,7 +96,8 @@ def test_multidim_cubes():
     result = regridder(mesh_cube)
 
     # Lenient check for data.
-    expected_data = np.zeros([t, n_lats, n_lons, h])
+    expected_data = np.empty([t, n_lats, n_lons, h])
+    expected_data[:] = np.arange(t * h).reshape(t, h)[:, np.newaxis, np.newaxis, :]
     assert np.allclose(expected_data, result.data)
 
     expected_cube = Cube(expected_data)

--- a/esmf_regrid/tests/unit/experimental/unstructured_scheme/test_MeshToGridESMFRegridder.py
+++ b/esmf_regrid/tests/unit/experimental/unstructured_scheme/test_MeshToGridESMFRegridder.py
@@ -1,6 +1,7 @@
 """Unit tests for :func:`esmf_regrid.experimental.unstructured_scheme.MeshToGridESMFRegridder`."""
 
 from iris.coords import AuxCoord, DimCoord
+from iris.cube import Cube
 import numpy as np
 import pytest
 
@@ -11,7 +12,7 @@ from esmf_regrid.tests.unit.experimental.unstructured_scheme.test__cube_to_GridI
     _grid_cube,
 )
 from esmf_regrid.tests.unit.experimental.unstructured_scheme.test__regrid_unstructured_to_rectilinear__prepare import (
-    _flat_mesh_cube,
+    _flat_mesh_cube, _full_mesh,
 )
 
 
@@ -56,6 +57,54 @@ def test_flat_cubes():
 
     # Check metadata and scalar coords.
     expected_cube.data = result.data
+    assert expected_cube == result
+
+
+def test_multidim_cubes():
+    """
+    Test for :func:`esmf_regrid.experimental.unstructured_scheme.MeshToGridESMFRegridder`.
+
+    Tests with multidimensional cubes. The source cube contains
+    coordinates on the dimensions before and after the mesh dimension.
+    """
+    mesh = _full_mesh()
+    mesh_length = mesh.connectivity(contains_face=True).shape[0]
+
+    h = 2
+    t = 3
+    height = DimCoord(np.arange(h), standard_name="height")
+    time = DimCoord(np.arange(t), standard_name="time")
+
+    mesh_cube = Cube(np.zeros([t, mesh_length, h]))
+    mesh_coord_x, mesh_coord_y = mesh.to_MeshCoords("face")
+    mesh_cube.add_aux_coord(mesh_coord_x, 1)
+    mesh_cube.add_aux_coord(mesh_coord_y, 1)
+    mesh_cube.add_dim_coord(time, 0)
+    mesh_cube.add_dim_coord(height, 2)
+
+    n_lons = 6
+    n_lats = 5
+    lon_bounds = (-180, 180)
+    lat_bounds = (-90, 90)
+    tgt = _grid_cube(n_lons, n_lats, lon_bounds, lat_bounds, circular=True)
+
+    src_cube = mesh_cube.copy()
+    src_cube.transpose([1, 0, 2])
+    regridder = MeshToGridESMFRegridder(src_cube, tgt)
+    result = regridder(mesh_cube)
+
+    # Lenient check for data.
+    expected_data = np.zeros([t, n_lats, n_lons, h])
+    assert np.allclose(expected_data, result.data)
+
+    expected_cube = Cube(expected_data)
+    expected_cube.add_dim_coord(time, 0)
+    expected_cube.add_dim_coord(tgt.coord("latitude"), 1)
+    expected_cube.add_dim_coord(tgt.coord("longitude"), 2)
+    expected_cube.add_dim_coord(height, 3)
+
+    # Check metadata and scalar coords.
+    result.data = expected_data
     assert expected_cube == result
 
 

--- a/esmf_regrid/tests/unit/experimental/unstructured_scheme/test_MeshToGridESMFRegridder.py
+++ b/esmf_regrid/tests/unit/experimental/unstructured_scheme/test_MeshToGridESMFRegridder.py
@@ -12,7 +12,8 @@ from esmf_regrid.tests.unit.experimental.unstructured_scheme.test__cube_to_GridI
     _grid_cube,
 )
 from esmf_regrid.tests.unit.experimental.unstructured_scheme.test__regrid_unstructured_to_rectilinear__prepare import (
-    _flat_mesh_cube, _full_mesh,
+    _flat_mesh_cube,
+    _full_mesh,
 )
 
 

--- a/esmf_regrid/tests/unit/experimental/unstructured_scheme/test_MeshToGridESMFRegridder.py
+++ b/esmf_regrid/tests/unit/experimental/unstructured_scheme/test_MeshToGridESMFRegridder.py
@@ -78,6 +78,7 @@ def test_multidim_cubes():
 
     src_data = np.empty([t, mesh_length, h])
     src_data[:] = np.arange(t * h).reshape([t, h])[:, np.newaxis, :]
+    mesh_cube = Cube(src_data)
     mesh_coord_x, mesh_coord_y = mesh.to_MeshCoords("face")
     mesh_cube.add_aux_coord(mesh_coord_x, 1)
     mesh_cube.add_aux_coord(mesh_coord_y, 1)

--- a/esmf_regrid/tests/unit/experimental/unstructured_scheme/test_regrid_unstructured_to_rectilinear.py
+++ b/esmf_regrid/tests/unit/experimental/unstructured_scheme/test_regrid_unstructured_to_rectilinear.py
@@ -1,6 +1,7 @@
 """Unit tests for :func:`esmf_regrid.experimental.unstructured_scheme.regrid_unstructured_to_rectilinear`."""
 
 from iris.coords import AuxCoord, DimCoord
+from iris.cube import Cube
 import numpy as np
 
 from esmf_regrid.experimental.unstructured_scheme import (
@@ -11,6 +12,7 @@ from esmf_regrid.tests.unit.experimental.unstructured_scheme.test__cube_to_GridI
 )
 from esmf_regrid.tests.unit.experimental.unstructured_scheme.test__regrid_unstructured_to_rectilinear__prepare import (
     _flat_mesh_cube,
+    _full_mesh,
 )
 
 
@@ -54,4 +56,52 @@ def test_flat_cubes():
 
     # Check metadata and scalar coords.
     expected_cube.data = result.data
+    assert expected_cube == result
+
+
+def test_multidim_cubes():
+    """
+    Test for :func:`esmf_regrid.experimental.unstructured_scheme.regrid_unstructured_to_rectilinear`.
+
+    Tests with multidimensional cubes. The source cube contains
+    coordinates on the dimensions before and after the mesh dimension.
+    """
+    mesh = _full_mesh()
+    mesh_length = mesh.connectivity(contains_face=True).shape[0]
+
+    h = 2
+    t = 3
+    height = DimCoord(np.arange(h), standard_name="height")
+    time = DimCoord(np.arange(t), standard_name="time")
+
+    src_data = np.empty([t, mesh_length, h])
+    src_data[:] = np.arange(t * h).reshape([t, h])[:, np.newaxis, :]
+    cube = Cube(src_data)
+    mesh_coord_x, mesh_coord_y = mesh.to_MeshCoords("face")
+    cube.add_aux_coord(mesh_coord_x, 1)
+    cube.add_aux_coord(mesh_coord_y, 1)
+    cube.add_dim_coord(time, 0)
+    cube.add_dim_coord(height, 2)
+
+    n_lons = 6
+    n_lats = 5
+    lon_bounds = (-180, 180)
+    lat_bounds = (-90, 90)
+    tgt = _grid_cube(n_lons, n_lats, lon_bounds, lat_bounds, circular=True)
+
+    result = regrid_unstructured_to_rectilinear(cube, tgt)
+
+    # Lenient check for data.
+    expected_data = np.empty([t, n_lats, n_lons, h])
+    expected_data[:] = np.arange(t * h).reshape(t, h)[:, np.newaxis, np.newaxis, :]
+    assert np.allclose(expected_data, result.data)
+
+    expected_cube = Cube(expected_data)
+    expected_cube.add_dim_coord(time, 0)
+    expected_cube.add_dim_coord(tgt.coord("latitude"), 1)
+    expected_cube.add_dim_coord(tgt.coord("longitude"), 2)
+    expected_cube.add_dim_coord(height, 3)
+
+    # Check metadata and scalar coords.
+    result.data = expected_data
     assert expected_cube == result


### PR DESCRIPTION
Provide support for cubes with extra dimensions. This change allows the regridding of cubes whose `mesh_dim` is any dimension. This is done by transposing the data before and after the regridding opperation. In future, this may be handled by the regridder itself (as opposed to the regridding scheme), however, keeping this functionality in a helper function allows the feature branch to stay more closely aligned with main.