### PR TITLE
Unstructured scheme integration test

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -32,6 +32,28 @@ env:
   CONDA_CACHE_PACKAGES: "nox pip pyyaml"
   # Use specific custom iris source feature branch.
   IRIS_SOURCE: "github:mesh-data-model"
+  # Git commit hash for iris test data.
+  IRIS_TEST_DATA_VERSION: "2.2"
+  # Base directory for the iris-test-data.
+  IRIS_TEST_DATA_DIR: ${HOME}/iris-test-data
+  # Iris config file location.
+  SITE_CFG: ${CIRRUS_WORKING_DIR}/lib/iris/etc/site.cfg
+
+
+#
+# YAML alias for the iris-test-data cache.
+#
+iris_test_data_template: &IRIS_TEST_DATA_TEMPLATE
+  data_cache:
+    folder: ${IRIS_TEST_DATA_DIR}
+    fingerprint_script:
+      - echo "iris-test-data v${IRIS_TEST_DATA_VERSION}"
+    populate_script:
+      - wget --quiet https://github.com/SciTools/iris-test-data/archive/v${IRIS_TEST_DATA_VERSION}.zip -O iris-test-data.zip
+      - unzip -q iris-test-data.zip
+      - mv iris-test-data-${IRIS_TEST_DATA_VERSION} ${IRIS_TEST_DATA_DIR}
+      - echo "[Resources]" > ${SITE_CFG}
+      - echo "test_data_dir = ${IRIS_TEST_DATA_DIR}/test_data" >> ${SITE_CFG}
 
 
 #
@@ -97,6 +119,7 @@ test_task:
       - echo "${CIRRUS_TASK_NAME}"
       - echo "${NOX_CACHE_BUILD}"
       - if [ -n "${IRIS_SOURCE}" ]; then echo "${IRIS_SOURCE}"; fi
+  << : *IRIS_TEST_DATA_TEMPLATE
   test_script:
     - export CONDA_OVERRIDE_LINUX="$(uname -r | cut -d'+' -f1)"
     - nox --session tests -- --verbose

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -36,8 +36,6 @@ env:
   IRIS_TEST_DATA_VERSION: "2.2"
   # Base directory for the iris-test-data.
   IRIS_TEST_DATA_DIR: ${HOME}/iris-test-data
-  # Iris config file location.
-  SITE_CFG: ${CIRRUS_WORKING_DIR}/lib/iris/etc/site.cfg
 
 
 #
@@ -52,8 +50,7 @@ iris_test_data_template: &IRIS_TEST_DATA_TEMPLATE
       - wget --quiet https://github.com/SciTools/iris-test-data/archive/v${IRIS_TEST_DATA_VERSION}.zip -O iris-test-data.zip
       - unzip -q iris-test-data.zip
       - mv iris-test-data-${IRIS_TEST_DATA_VERSION} ${IRIS_TEST_DATA_DIR}
-      - echo "[Resources]" > ${SITE_CFG}
-      - echo "test_data_dir = ${IRIS_TEST_DATA_DIR}/test_data" >> ${SITE_CFG}
+      - export OVERRIDE_TEST_DATA_REPOSITORY=${IRIS_TEST_DATA_DIR}
 
 
 #

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -50,7 +50,6 @@ iris_test_data_template: &IRIS_TEST_DATA_TEMPLATE
       - wget --quiet https://github.com/SciTools/iris-test-data/archive/v${IRIS_TEST_DATA_VERSION}.zip -O iris-test-data.zip
       - unzip -q iris-test-data.zip
       - mv iris-test-data-${IRIS_TEST_DATA_VERSION} ${IRIS_TEST_DATA_DIR}
-      - export OVERRIDE_TEST_DATA_REPOSITORY=${IRIS_TEST_DATA_DIR}
 
 
 #
@@ -119,4 +118,5 @@ test_task:
   << : *IRIS_TEST_DATA_TEMPLATE
   test_script:
     - export CONDA_OVERRIDE_LINUX="$(uname -r | cut -d'+' -f1)"
+    - export OVERRIDE_TEST_DATA_REPOSITORY=${IRIS_TEST_DATA_DIR}
     - nox --session tests -- --verbose

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -36,6 +36,7 @@ env:
   IRIS_TEST_DATA_VERSION: "2.2"
   # Base directory for the iris-test-data.
   IRIS_TEST_DATA_DIR: ${HOME}/iris-test-data
+  OVERRIDE_TEST_DATA_REPOSITORY: ${IRIS_TEST_DATA_DIR}/test_data
 
 
 #
@@ -118,5 +119,4 @@ test_task:
   << : *IRIS_TEST_DATA_TEMPLATE
   test_script:
     - export CONDA_OVERRIDE_LINUX="$(uname -r | cut -d'+' -f1)"
-    - export OVERRIDE_TEST_DATA_REPOSITORY=${IRIS_TEST_DATA_DIR}
     - nox --session tests -- --verbose

--- a/esmf_regrid/tests/integration/experimental/__init__.py
+++ b/esmf_regrid/tests/integration/experimental/__init__.py
@@ -1,0 +1,1 @@
+"""Integration tests for :mod:`esmf_regrid.experimental`."""

--- a/esmf_regrid/tests/integration/experimental/unstructured_scheme/__init__.py
+++ b/esmf_regrid/tests/integration/experimental/unstructured_scheme/__init__.py
@@ -1,0 +1,1 @@
+"""Integration tests for :mod:`esmf_regrid.experimental.unstructured_scheme`."""

--- a/esmf_regrid/tests/integration/experimental/unstructured_scheme/test_regrid_unstructured_to_rectilinear.py
+++ b/esmf_regrid/tests/integration/experimental/unstructured_scheme/test_regrid_unstructured_to_rectilinear.py
@@ -8,7 +8,7 @@ from iris.experimental.ugrid import PARSE_UGRID_ON_LOAD
 
 def test_real_data():
     test_data_dir = iris.config.TEST_DATA_DIR
-    fn = os.path.join(test_data_dir, "test_data", "NetCDF", "unstructured_grid", "lfric_ngvat_3D_snow_pseudo_levels_1t_face_half_levels_main_snow_layer_temp.nc")
+    fn = os.path.join(test_data_dir, "NetCDF", "unstructured_grid", "lfric_ngvat_3D_snow_pseudo_levels_1t_face_half_levels_main_snow_layer_temp.nc")
     with PARSE_UGRID_ON_LOAD.context():
         cubes = iris.load(fn)
         cube = iris.load_cube(fn, "snow_layer_temperature")

--- a/esmf_regrid/tests/integration/experimental/unstructured_scheme/test_regrid_unstructured_to_rectilinear.py
+++ b/esmf_regrid/tests/integration/experimental/unstructured_scheme/test_regrid_unstructured_to_rectilinear.py
@@ -2,13 +2,45 @@
 
 
 import os
+
 import iris
 from iris.experimental.ugrid import PARSE_UGRID_ON_LOAD
+import numpy as np
+
+from esmf_regrid.experimental.unstructured_scheme import (
+    regrid_unstructured_to_rectilinear,
+)
 
 
 def test_real_data():
+    """
+    Test for :func:`esmf_regrid.experimental.unstructured_scheme.regrid_unstructured_to_rectilinear`.
+
+    Tests with cubes derived from realistic data.
+    """
+    # Load source cube.
     test_data_dir = iris.config.TEST_DATA_DIR
-    fn = os.path.join(test_data_dir, "NetCDF", "unstructured_grid", "lfric_ngvat_3D_snow_pseudo_levels_1t_face_half_levels_main_snow_layer_temp.nc")
+    src_fn = os.path.join(test_data_dir, "NetCDF", "unstructured_grid", "lfric_surface_mean.nc")
     with PARSE_UGRID_ON_LOAD.context():
-        cubes = iris.load(fn)
-        cube = iris.load_cube(fn, "snow_layer_temperature")
+        src = iris.load_cube(src_fn, "rainfall_flux")
+
+    # Load target grid cube.
+    tgt_fn = os.path.join(test_data_dir, "NetCDF", "global", "xyt", "SMALL_hires_wind_u_for_ipcc4.nc")
+    tgt = iris.load_cube(tgt_fn)
+
+    # Perform regridding.
+    result = regrid_unstructured_to_rectilinear(src, tgt)
+
+    # Check data.
+    assert result.shape == (1, 160, 320)
+    assert np.isclose(result.data.mean(), 2.93844e-5)
+    assert np.isclose(result.data.std(), 2.71724e-5)
+
+    # Check metadata.
+    assert result.metadata == src.metadata
+    assert result.coord("time") == src.coord("time")
+    assert result.coord("latitude") == tgt.coord("latitude")
+    assert result.coord("longitude") == tgt.coord("longitude")
+    assert result.coord_dims("time") == (0,)
+    assert result.coord_dims("latitude") == (1,)
+    assert result.coord_dims("longitude") == (2,)

--- a/esmf_regrid/tests/integration/experimental/unstructured_scheme/test_regrid_unstructured_to_rectilinear.py
+++ b/esmf_regrid/tests/integration/experimental/unstructured_scheme/test_regrid_unstructured_to_rectilinear.py
@@ -8,7 +8,7 @@ from iris.experimental.ugrid import PARSE_UGRID_ON_LOAD
 
 def test_real_data():
     test_data_dir = iris.config.TEST_DATA_DIR
-    fn = os.path.join(test_data_dir, "NetCDF", "unstructured_grid", "lfric_ngvat_3D_snow_pseudo_levels_1t_face_half_levels_main_snow_layer_temp.nc")
+    fn = os.path.join(test_data_dir, "test_data", "NetCDF", "unstructured_grid", "lfric_ngvat_3D_snow_pseudo_levels_1t_face_half_levels_main_snow_layer_temp.nc")
     with PARSE_UGRID_ON_LOAD.context():
         cubes = iris.load(fn)
         cube = iris.load_cube(fn, "snow_layer_temperature")

--- a/esmf_regrid/tests/integration/experimental/unstructured_scheme/test_regrid_unstructured_to_rectilinear.py
+++ b/esmf_regrid/tests/integration/experimental/unstructured_scheme/test_regrid_unstructured_to_rectilinear.py
@@ -20,12 +20,16 @@ def test_real_data():
     """
     # Load source cube.
     test_data_dir = iris.config.TEST_DATA_DIR
-    src_fn = os.path.join(test_data_dir, "NetCDF", "unstructured_grid", "lfric_surface_mean.nc")
+    src_fn = os.path.join(
+        test_data_dir, "NetCDF", "unstructured_grid", "lfric_surface_mean.nc"
+    )
     with PARSE_UGRID_ON_LOAD.context():
         src = iris.load_cube(src_fn, "rainfall_flux")
 
     # Load target grid cube.
-    tgt_fn = os.path.join(test_data_dir, "NetCDF", "global", "xyt", "SMALL_hires_wind_u_for_ipcc4.nc")
+    tgt_fn = os.path.join(
+        test_data_dir, "NetCDF", "global", "xyt", "SMALL_hires_wind_u_for_ipcc4.nc"
+    )
     tgt = iris.load_cube(tgt_fn)
 
     # Perform regridding.

--- a/esmf_regrid/tests/integration/experimental/unstructured_scheme/test_regrid_unstructured_to_rectilinear.py
+++ b/esmf_regrid/tests/integration/experimental/unstructured_scheme/test_regrid_unstructured_to_rectilinear.py
@@ -1,0 +1,14 @@
+"""Integration tests for :func:`esmf_regrid.experimental.unstructured_scheme.regrid_unstructured_to_rectilinear`."""
+
+
+import os
+import iris
+from iris.experimental.ugrid import PARSE_UGRID_ON_LOAD
+
+
+def test_real_data():
+    test_data_dir = iris.config.TEST_DATA_DIR
+    fn = os.path.join(test_data_dir, "NetCDF", "unstructured_grid", "lfric_ngvat_3D_snow_pseudo_levels_1t_face_half_levels_main_snow_layer_temp.nc")
+    with PARSE_UGRID_ON_LOAD.context():
+        cubes = iris.load(fn)
+        cube = iris.load_cube(fn, "snow_layer_temperature")


### PR DESCRIPTION
Addresses the integration test part of #61 for the unstructured regridder. Adds support for testing with files from iris-test-data.