### PR TITLE
Add nox to excludes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ exclude = '''
     | \.git          # root of the project
     | \.hg
     | \.mypy_cache
+    | \.nox
     | \.tox
     | \.venv
     | _build


### PR DESCRIPTION
This adds the `.nox` directory to the excludes in `pyproject.toml` alongside `.tox` to avoid unnecessary checks of embedded python files.

Closes #71