### PR TITLE
CI Benchmarking

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -17,10 +17,8 @@ container:
 env:
   # Skip specific tasks by name. Set to a non-empty string to skip.
   SKIP_LINT_TASK: ""
-  SKIP_TEST_TASK: ""
-  # Currently disabled:
-  #  https://github.com/SciTools-incubator/iris-esmf-regrid/pull/76#issuecomment-850378861
-  SKIP_BENCHMARK_TASK: "."
+  SKIP_TEST_TASK: "."
+  SKIP_BENCHMARK_TASK: ""
   # Maximum cache period (in weeks) before forcing a new cache upload.
   CACHE_PERIOD: "2"
   # Increment the build number to force new conda cache upload.

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -124,5 +124,6 @@ benchmark_task:
       - echo "${CIRRUS_TASK_NAME}"
       - if [ -n "${IRIS_SOURCE}" ]; then echo "${IRIS_SOURCE}"; fi
   benchmarks_script:
+    - which git
     - export CONDA_OVERRIDE_LINUX="$(uname -r | cut -d'+' -f1)"
-    - nox --session "benchmarks(ci_mode=True)"
+#    - nox --session "benchmarks(ci_mode=True)"

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -124,7 +124,7 @@ benchmark_task:
       git reset --hard $CIRRUS_CHANGE_IN_REPO
     else
       git clone --recursive https://x-access-token:${CIRRUS_REPO_CLONE_TOKEN}@github.com/${CIRRUS_REPO_FULL_NAME}.git $CIRRUS_WORKING_DIR
-      git fetch origin pull/$CIRRUS_PR/head:pull/$CIRRUS_PR
+      git fetch origin pull/${CIRRUS_PR}/head:pull/${CIRRUS_PR}
       git reset --hard $CIRRUS_CHANGE_IN_REPO
     fi
   << : *LINUX_CONDA_TEMPLATE

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -116,6 +116,9 @@ benchmark_task:
   only_if: ${SKIP_BENCHMARK_TASK} == ""
   auto_cancellation: true
   name: "${CIRRUS_OS}: performance benchmarking"
+  clone_script: |
+    git clone --branch=$CIRRUS_BRANCH https://x-access-token:${CIRRUS_REPO_CLONE_TOKEN}@github.com/${CIRRUS_REPO_FULL_NAME}.git $CIRRUS_WORKING_DIR
+    git reset --hard $CIRRUS_CHANGE_IN_REPO
   << : *LINUX_CONDA_TEMPLATE
   asv_cache:
     folder: ${CIRRUS_WORKING_DIR}/benchmarks/.asv-env
@@ -123,9 +126,6 @@ benchmark_task:
     fingerprint_script:
       - echo "${CIRRUS_TASK_NAME}"
       - if [ -n "${IRIS_SOURCE}" ]; then echo "${IRIS_SOURCE}"; fi
-  clone_script: |
-    git clone --branch=$CIRRUS_BRANCH https://x-access-token:${CIRRUS_REPO_CLONE_TOKEN}@github.com/${CIRRUS_REPO_FULL_NAME}.git $CIRRUS_WORKING_DIR
-    git reset --hard $CIRRUS_CHANGE_IN_REPO
   benchmarks_script:
     - export CONDA_OVERRIDE_LINUX="$(uname -r | cut -d'+' -f1)"
     - nox --session "benchmarks(ci_mode=True)"

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -17,7 +17,7 @@ container:
 env:
   # Skip specific tasks by name. Set to a non-empty string to skip.
   SKIP_LINT_TASK: ""
-  SKIP_TEST_TASK: "."
+  SKIP_TEST_TASK: ""
   SKIP_BENCHMARK_TASK: ""
   # Maximum cache period (in weeks) before forcing a new cache upload.
   CACHE_PERIOD: "2"
@@ -116,7 +116,8 @@ benchmark_task:
   only_if: ${SKIP_BENCHMARK_TASK} == ""
   auto_cancellation: true
   name: "${CIRRUS_OS}: performance benchmarking"
-  # Need different behaviour to access the PR state if on a PR.
+  # Custom clone behaviour to enable ASV to access the PR base branch (if on a
+  #  PR).
   clone_script: |
     if [ -z "$CIRRUS_PR" ]; then
       git clone --branch=$CIRRUS_BRANCH https://x-access-token:${CIRRUS_REPO_CLONE_TOKEN}@github.com/${CIRRUS_REPO_FULL_NAME}.git $CIRRUS_WORKING_DIR
@@ -135,12 +136,10 @@ benchmark_task:
       - if [ -n "${IRIS_SOURCE}" ]; then echo "${IRIS_SOURCE}"; fi
   benchmarks_script:
     - export CONDA_OVERRIDE_LINUX="$(uname -r | cut -d'+' -f1)"
+    - nox --session="benchmarks(ci compare)"
+    # If running on the main branch (i.e. post-merge):
+    #  Run the full benchmark sequence then publish (``asv gh-pages``).
     - |
-      if [ -z "$CIRRUS_PR" ]; then
-        nox --session "benchmarks(ci_mode=True)"
-        if [ "$CIRRUS_BRANCH" == "$CIRRUS_DEFAULT_BRANCH"]; then
-          nox --session "benchmarks(ci_mode=False)"
-
-      else
-        nox --session "benchmarks(ci_mode=True)"
+      if [ "$CIRRUS_BRANCH" == "$CIRRUS_DEFAULT_BRANCH" ]; then
+        nox --session="benchmarks(full then publish)"
       fi

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -117,7 +117,7 @@ benchmark_task:
   auto_cancellation: true
   name: "${CIRRUS_OS}: performance benchmarking"
   clone_script: |
-    git clone --branch=$CIRRUS_BRANCH https://x-access-token:${CIRRUS_REPO_CLONE_TOKEN}@github.com/${CIRRUS_REPO_FULL_NAME}.git $CIRRUS_WORKING_DIR
+    git clone --branch=ci_benchmarking https://x-access-token:${CIRRUS_REPO_CLONE_TOKEN}@github.com/${CIRRUS_REPO_FULL_NAME}.git $CIRRUS_WORKING_DIR
     git reset --hard $CIRRUS_CHANGE_IN_REPO
   << : *LINUX_CONDA_TEMPLATE
   asv_cache:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -116,9 +116,16 @@ benchmark_task:
   only_if: ${SKIP_BENCHMARK_TASK} == ""
   auto_cancellation: true
   name: "${CIRRUS_OS}: performance benchmarking"
+  # Need different behaviour to access the PR state if on a PR.
   clone_script: |
-    git clone --branch=ci_benchmarking https://x-access-token:${CIRRUS_REPO_CLONE_TOKEN}@github.com/${CIRRUS_REPO_FULL_NAME}.git $CIRRUS_WORKING_DIR
-    git reset --hard $CIRRUS_CHANGE_IN_REPO
+    if [ -z "$CIRRUS_PR" ]; then
+      git clone --branch=$CIRRUS_BRANCH https://x-access-token:${CIRRUS_REPO_CLONE_TOKEN}@github.com/${CIRRUS_REPO_FULL_NAME}.git $CIRRUS_WORKING_DIR
+      git reset --hard $CIRRUS_CHANGE_IN_REPO
+    else
+      git clone --recursive https://x-access-token:${CIRRUS_REPO_CLONE_TOKEN}@github.com/${CIRRUS_REPO_FULL_NAME}.git $CIRRUS_WORKING_DIR
+      git fetch origin pull/$CIRRUS_PR/head:pull/$CIRRUS_PR
+      git reset --hard $CIRRUS_CHANGE_IN_REPO
+    fi
   << : *LINUX_CONDA_TEMPLATE
   asv_cache:
     folder: ${CIRRUS_WORKING_DIR}/benchmarks/.asv-env
@@ -128,4 +135,9 @@ benchmark_task:
       - if [ -n "${IRIS_SOURCE}" ]; then echo "${IRIS_SOURCE}"; fi
   benchmarks_script:
     - export CONDA_OVERRIDE_LINUX="$(uname -r | cut -d'+' -f1)"
-    - nox --session "benchmarks(ci_mode=True)"
+    - |
+      if [ -z "$CIRRUS_PR" ]; then
+        nox --session "benchmarks(ci_mode=False)"
+      else
+        nox --session "benchmarks(ci_mode=True)"
+      fi

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -137,7 +137,10 @@ benchmark_task:
     - export CONDA_OVERRIDE_LINUX="$(uname -r | cut -d'+' -f1)"
     - |
       if [ -z "$CIRRUS_PR" ]; then
-        nox --session "benchmarks(ci_mode=False)"
+        nox --session "benchmarks(ci_mode=True)"
+        if [ "$CIRRUS_BRANCH" == "$CIRRUS_DEFAULT_BRANCH"]; then
+          nox --session "benchmarks(ci_mode=False)"
+
       else
         nox --session "benchmarks(ci_mode=True)"
       fi

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -123,7 +123,9 @@ benchmark_task:
     fingerprint_script:
       - echo "${CIRRUS_TASK_NAME}"
       - if [ -n "${IRIS_SOURCE}" ]; then echo "${IRIS_SOURCE}"; fi
+  clone_script: |
+    git clone --branch=$CIRRUS_BRANCH https://x-access-token:${CIRRUS_REPO_CLONE_TOKEN}@github.com/${CIRRUS_REPO_FULL_NAME}.git $CIRRUS_WORKING_DIR
+    git reset --hard $CIRRUS_CHANGE_IN_REPO
   benchmarks_script:
-    - which git
     - export CONDA_OVERRIDE_LINUX="$(uname -r | cut -d'+' -f1)"
-#    - nox --session "benchmarks(ci_mode=True)"
+    - nox --session "benchmarks(ci_mode=True)"

--- a/benchmarks/asv.conf.json
+++ b/benchmarks/asv.conf.json
@@ -10,5 +10,5 @@
     "html_dir": ".asv-html",
     "project_url": "https://github.com/SciTools-incubator/iris-esmf-regrid",
     "show_commit_url": "https://github.com/SciTools-incubator/iris-esmf-regrid/commit/",
-    "plugins": ["nox_asv_plugin"],
+    "plugins": [".nox_asv_plugin"],
 }

--- a/benchmarks/asv.conf.json
+++ b/benchmarks/asv.conf.json
@@ -4,6 +4,7 @@
     "repo": "..",
     "environment_type": "nox-conda",
     "pythons": [],
+    "branches": ["main"],
     "benchmark_dir": "benchmarks",
     "env_dir": ".asv-env",
     "results_dir": ".asv-results",

--- a/noxfile.py
+++ b/noxfile.py
@@ -357,11 +357,10 @@ def benchmarks(session: nox.sessions.Session, ci_mode: bool):
     the benchmarking environment.
 
     """
-    session.run_always("which", "git")
-    # session.install("asv", "nox", "pyyaml")
-    # session.cd("benchmarks")
-    # # Skip over setup questions for a new machine.
-    # session.run("asv", "machine", "--yes")
+    session.install("asv", "nox", "pyyaml")
+    session.cd("benchmarks")
+    # Skip over setup questions for a new machine.
+    session.run("asv", "machine", "--yes")
 
     def asv_exec(sub_command: List[str]) -> None:
         session.run(
@@ -370,9 +369,10 @@ def benchmarks(session: nox.sessions.Session, ci_mode: bool):
             f"--python={PY_VER[-1]}",
         )
 
-    # if ci_mode:
-    #     asv_exec(["continuous", "HEAD^1", "HEAD", "--bench=ci"])
-    #     asv_exec(["compare", "HEAD^1", "HEAD"])
-    # else:
-    #     # f32f23a5 = first supporting commit for nox_asv_plugin.py .
-    #     asv_exec(["run", "f32f23a5..HEAD"])
+    if ci_mode:
+        previous_commit = os.environ.get("CIRRUS_BASE_SHA", "HEAD^1")
+        asv_exec(["continuous", previous_commit, "HEAD", "--bench=ci"])
+        asv_exec(["compare", previous_commit, "HEAD"])
+    else:
+        # f32f23a5 = first supporting commit for nox_asv_plugin.py .
+        asv_exec(["run", "f32f23a5..HEAD"])

--- a/noxfile.py
+++ b/noxfile.py
@@ -360,7 +360,7 @@ def benchmarks(session: nox.sessions.Session, ci_mode: bool):
     test_string = (
         'from os import environ; print(environ.get("CIRRUS_BASE_SHA", "NONE"))'
     )
-    session.run_always(f"python -c '{test_string}'")
+    session.run_always("python", "-c", test_string)
     session.install("asv", "nox", "pyyaml")
     session.cd("benchmarks")
     # Skip over setup questions for a new machine.

--- a/noxfile.py
+++ b/noxfile.py
@@ -357,14 +357,11 @@ def benchmarks(session: nox.sessions.Session, ci_mode: bool):
     the benchmarking environment.
 
     """
-    test_string = (
-        'from os import environ; print(environ.get("CIRRUS_BASE_SHA", "NONE"))'
-    )
-    session.run_always("python", "-c", test_string)
-    session.install("asv", "nox", "pyyaml")
-    session.cd("benchmarks")
-    # Skip over setup questions for a new machine.
-    session.run("asv", "machine", "--yes")
+    session.run_always("which", "git")
+    # session.install("asv", "nox", "pyyaml")
+    # session.cd("benchmarks")
+    # # Skip over setup questions for a new machine.
+    # session.run("asv", "machine", "--yes")
 
     def asv_exec(sub_command: List[str]) -> None:
         session.run(
@@ -373,9 +370,9 @@ def benchmarks(session: nox.sessions.Session, ci_mode: bool):
             f"--python={PY_VER[-1]}",
         )
 
-    if ci_mode:
-        asv_exec(["continuous", "HEAD^1", "HEAD", "--bench=ci"])
-        asv_exec(["compare", "HEAD^1", "HEAD"])
-    else:
-        # f32f23a5 = first supporting commit for nox_asv_plugin.py .
-        asv_exec(["run", "f32f23a5..HEAD"])
+    # if ci_mode:
+    #     asv_exec(["continuous", "HEAD^1", "HEAD", "--bench=ci"])
+    #     asv_exec(["compare", "HEAD^1", "HEAD"])
+    # else:
+    #     # f32f23a5 = first supporting commit for nox_asv_plugin.py .
+    #     asv_exec(["run", "f32f23a5..HEAD"])

--- a/noxfile.py
+++ b/noxfile.py
@@ -338,9 +338,7 @@ def tests(session: nox.sessions.Session):
 
 
 @nox.session
-# CI_MODE=TRUE IS CURRENTLY DISABLED:
-#  https://github.com/SciTools-incubator/iris-esmf-regrid/pull/76#issuecomment-850378861
-@nox.parametrize("ci_mode", [False])
+@nox.parametrize("ci_mode", [False, True])
 def benchmarks(session: nox.sessions.Session, ci_mode: bool):
     """
     Perform esmf-regrid performance benchmarks (using Airspeed Velocity).
@@ -359,6 +357,7 @@ def benchmarks(session: nox.sessions.Session, ci_mode: bool):
     the benchmarking environment.
 
     """
+    print(os.environ.get("CIRRUS_BASE_SHA", "NONE"))
     session.install("asv", "nox", "pyyaml")
     session.cd("benchmarks")
     # Skip over setup questions for a new machine.

--- a/noxfile.py
+++ b/noxfile.py
@@ -357,7 +357,10 @@ def benchmarks(session: nox.sessions.Session, ci_mode: bool):
     the benchmarking environment.
 
     """
-    print(os.environ.get("CIRRUS_BASE_SHA", "NONE"))
+    test_string = (
+        "from os import environ; print(environ.get('CIRRUS_BASE_SHA', 'NONE'))"
+    )
+    session.run_always(f"python -c {test_string}")
     session.install("asv", "nox", "pyyaml")
     session.cd("benchmarks")
     # Skip over setup questions for a new machine.

--- a/noxfile.py
+++ b/noxfile.py
@@ -358,9 +358,9 @@ def benchmarks(session: nox.sessions.Session, ci_mode: bool):
 
     """
     test_string = (
-        "from os import environ; print(environ.get('CIRRUS_BASE_SHA', 'NONE'))"
+        'from os import environ; print(environ.get("CIRRUS_BASE_SHA", "NONE"))'
     )
-    session.run_always(f"python -c {test_string}")
+    session.run_always(f"python -c '{test_string}'")
     session.install("asv", "nox", "pyyaml")
     session.cd("benchmarks")
     # Skip over setup questions for a new machine.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ exclude = '''
     | \.nox
     | \.tox
     | \.venv
-    | \benchmarks\.asv*
+    | benchmarks\/\.asv.*
     | _build
     | buck-out
     | build

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,8 +13,8 @@ exclude = '''
     | \.nox
     | \.tox
     | \.venv
-    | benchmarks\/\.asv.*
     | _build
+    | benchmarks\/\.asv.*
     | buck-out
     | build
     | dist


### PR DESCRIPTION
* Enable benchmark integration into CI.
* Post-merge full run including publishing to a `gh-pages` branch.
  If this ends up running too long we can review. Perhaps a smaller range, skipping commits, or something completely different.
* A fix for `pyproject.toml`, without which Black will run on all ASV environments as well as the source code.