### PR TITLE
Don't attempt ASV results publish after merging.

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -137,11 +137,3 @@ benchmark_task:
   benchmarks_script:
     - export CONDA_OVERRIDE_LINUX="$(uname -r | cut -d'+' -f1)"
     - nox --session="benchmarks(ci compare)"
-    # If running on the main branch (i.e. post-merge):
-    #  Run the full benchmark sequence then publish (``asv gh-pages``).
-    - |
-      if [ "$CIRRUS_BRANCH" == "$CIRRUS_DEFAULT_BRANCH" ]; then
-        git config user.email "."
-        git config user.name "Airspeed Velocity automated"
-        nox --session="benchmarks(full then publish)"
-      fi


### PR DESCRIPTION
From testing I have found that by default [Cirrus does not have push/write permissions](https://cirrus-ci.com/task/5279086701445120?logs=benchmarks#L57-62).

These permissions can be granted by [generating an access token for Cirrus](https://cirrus-ci.org/api/#authorization). However this feels like a security loophole, since as far as I can see there would be nothing preventing a malicious push, by proposing this as a change to `cirrus.yml` within a PR. The GitHub actions documentation talks extensively about such risks ([e.g.](https://github.blog/2020-08-03-github-actions-improvements-for-fork-and-pull-request-workflows/#improvements-for-public-repository-forks)), and has securities in place, but I can't find any such mention in Cirrus' documentation.

It may be possible to write a specific GitHub Action for ASV run-and-publish after merging to `main`, but this will require another dedicated piece of work.

So for now, we should just remove the code that attempts the run-and-publish step.