### PR TITLE
Rename lockfile_dir to avoid builtin name

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -43,14 +43,14 @@ def _lockfile_path(py_string: str, platform_placeholder: bool = False) -> Path:
     ``--filename-template``.
 
     """
-    dir = Path() / "requirements" / "nox.lock"
+    lockfile_dir = Path() / "requirements" / "nox.lock"
     name_template = "{py_string}-{platform}.lock"
     if platform_placeholder:
         platform = "{platform}"
     else:
         platform = LOCKFILE_PLATFORM
     lockfile_name = name_template.format(py_string=py_string, platform=platform)
-    return dir / lockfile_name
+    return lockfile_dir / lockfile_name
 
 
 def _session_lockfile(session: nox.sessions.Session) -> Path:


### PR DESCRIPTION
Noticed this small issue: in one of the noxfile functions, it names a variable `dir`. [dir is a built in function](https://docs.python.org/3/library/functions.html#dir) so it shouldn't be used to as a variable name, as it overrides the builtin function.
