### PR TITLE
Add grid to mesh scheme

### DIFF
--- a/esmf_regrid/experimental/unstructured_scheme.py
+++ b/esmf_regrid/experimental/unstructured_scheme.py
@@ -551,8 +551,11 @@ class GridToMeshESMFRegridder:
 
         """
         grid_x, grid_y = get_xy_dim_coords(cube)
-        assert grid_x == self.grid_x
-        assert grid_y == self.grid_y
+        if (grid_x != self.grid_x) or (grid_y != self.grid_y):
+            raise ValueError(
+                "The given cube is not defined on the same "
+                "source grid as this regridder."
+            )
 
         grid_x_dim = cube.coord_dims(grid_x)[0]
         grid_y_dim = cube.coord_dims(grid_y)[0]

--- a/esmf_regrid/experimental/unstructured_scheme.py
+++ b/esmf_regrid/experimental/unstructured_scheme.py
@@ -327,6 +327,8 @@ class MeshToGridESMFRegridder:
 
 
 def _regrid_along_grid_dims(regridder, data, grid_x_dim, grid_y_dim, mdtol):
+    # The mesh will be assigned to the first dimension associated with the
+    # grid, whether that is associated with the x or y coordinate.
     tgt_mesh_dim = min(grid_x_dim, grid_y_dim)
     data = np.moveaxis(data, [grid_x_dim, grid_y_dim], [-1, -2])
     result = regridder.regrid(data, mdtol=mdtol)
@@ -457,7 +459,9 @@ def regrid_rectilinear_to_unstructured(src_cube, mesh_cube, mdtol=0):
     Return a new cube with data values calculated using the area weighted
     mean of data values from rectilinear cube src_cube regridded onto the
     horizontal mesh of mesh_cube. The dimensions on the cube associated
-    with the grid will replaced by a dimensions associated with the mesh.
+    with the grid will replaced by a dimension associated with the mesh.
+    That dimension will be the the first of the grid dimensions, whether
+    it is associated with the x or y coordinate.
     This function requires that the horizontal dimension of mesh_cube is
     described by a 2D mesh with data located on the faces of that mesh.
     This function requires that the horizontal grid of src_cube is

--- a/esmf_regrid/experimental/unstructured_scheme.py
+++ b/esmf_regrid/experimental/unstructured_scheme.py
@@ -512,7 +512,7 @@ class GridToMeshESMFRegridder:
             area-weighted regridding via ESMF generated weights.
 
         """
-        grid_x, grid_y = get_xy_dim_coords(src_grid_cube)
+        grid_x, grid_y = get_xy_dim_coords(cube)
         assert grid_x == self.grid_x
         assert grid_y == self.grid_y
 

--- a/esmf_regrid/experimental/unstructured_scheme.py
+++ b/esmf_regrid/experimental/unstructured_scheme.py
@@ -450,8 +450,45 @@ def _regrid_rectilinear_to_unstructured__perform(src_cube, regrid_info, mdtol):
     return new_cube
 
 
-def regrid_rectilinear_to_unstructured(src_cube, grid_cube, mdtol=0):
-    regrid_info = _regrid_rectilinear_to_unstructured__prepare(src_cube, grid_cube)
+def regrid_rectilinear_to_unstructured(src_cube, mesh_cube, mdtol=0):
+    """
+    Regrid rectilinear cube onto unstructured mesh.
+
+    Return a new cube with data values calculated using the area weighted
+    mean of data values from rectilinear cube src_cube regridded onto the
+    horizontal mesh of mesh_cube. The dimensions on the cube associated
+    with the grid will replaced by a dimensions associated with the mesh.
+    This function requires that the horizontal dimension of mesh_cube is
+    described by a 2D mesh with data located on the faces of that mesh.
+    This function requires that the horizontal grid of src_cube is
+    rectilinear (i.e. expressed in terms of two orthogonal 1D coordinates).
+    This function also requires that the coordinates describing the
+    horizontal grid have bounds.
+
+    Parameters
+    ----------
+    src_cube : cube
+        A rectilinear instance of iris.cube.Cube that supplies the data,
+        metadata and coordinates.
+    mesh_cube : cube
+        An unstructured instance of iris.cube.Cube that supplies the desired
+        horizontal mesh definition.
+    mdtol : float, optional
+        Tolerance of missing data. The value returned in each element of the
+        returned cube's data array will be masked if the fraction of masked
+        data in the overlapping cells of the source cube exceeds mdtol. This
+        fraction is calculated based on the area of masked cells within each
+        target cell. mdtol=0 means no missing data is tolerated while mdtol=1
+        will mean the resulting element will be masked if and only if all the
+        overlapping cells of the source cube are masked. Defaults to 0.
+
+    Returns
+    -------
+    cube
+        A new iris.cube.Cube instance.
+
+    """
+    regrid_info = _regrid_rectilinear_to_unstructured__prepare(src_cube, mesh_cube)
     result = _regrid_rectilinear_to_unstructured__perform(src_cube, regrid_info, mdtol)
     return result
 

--- a/esmf_regrid/experimental/unstructured_scheme.py
+++ b/esmf_regrid/experimental/unstructured_scheme.py
@@ -86,7 +86,7 @@ def _create_cube(data, src_cube, mesh_dim, grid_x, grid_y):
         The regridded data as an N-dimensional NumPy array.
     src_cube : cube
         The source Cube.
-    mes_dim : int
+    mesh_dim : int
         The dimension of the mesh within the source Cube.
     grid_x : DimCoord
         The :class:`iris.coords.DimCoord` for the new grid's X
@@ -187,7 +187,7 @@ def _regrid_unstructured_to_rectilinear__perform(src_cube, regrid_info, mdtol):
     """
     Second (regrid) part of 'regrid_unstructured_to_rectilinear'.
 
-    Perform the prepared regrid calculation on a single 2d cube.
+    Perform the prepared regrid calculation on a single cube.
 
     """
     mesh_dim, grid_x, grid_y, regridder = regrid_info
@@ -322,5 +322,212 @@ class MeshToGridESMFRegridder:
         regrid_info = (mesh_dim, self.grid_x, self.grid_y, self.regridder)
 
         return _regrid_unstructured_to_rectilinear__perform(
+            cube, regrid_info, self.mdtol
+        )
+
+
+def _regrid_along_grid_dims(regridder, data, grid_x_dim, grid_y_dim, mdtol):
+    tgt_mesh_dim = min(grid_x_dim, grid_y_dim)
+    data = np.moveaxis(data, [grid_x_dim, grid_y_dim], [-1, -2])
+    result = regridder.regrid(data, mdtol=mdtol)
+
+    result = np.moveaxis(result, -1, tgt_mesh_dim)
+    return result
+
+
+def _create_mesh_cube(data, src_cube, grid_dim_x, grid_dim_y, mesh):
+    """
+    Return a new cube for the result of regridding.
+
+    Returned cube represents the result of regridding the source cube
+    onto the new mesh.
+    All the metadata and coordinates of the result cube are copied from
+    the source cube, with two exceptions:
+        - Grid dimension coordinates are copied from the grid cube.
+        - Auxiliary coordinates which span the mesh dimension are
+          ignored.
+
+    Parameters
+    ----------
+    data : array
+        The regridded data as an N-dimensional NumPy array.
+    src_cube : cube
+        The source Cube.
+    grid_dim_x : int
+        The dimension of the x dimension on the source Cube.
+    grid_dim_y : int
+        The dimension of the x dimension on the source Cube.
+    mesh : Mesh
+        The :class:`iris.experimental.ugrid.Mesh` for the new
+        Cube.
+
+    Returns
+    -------
+    cube
+        A new iris.cube.Cube instance.
+
+    """
+    new_cube = iris.cube.Cube(data)
+
+    min_grid_dim = min(grid_dim_x, grid_dim_y)
+    max_grid_dim = max(grid_dim_x, grid_dim_y)
+    for coord in mesh.to_MeshCoords("face"):
+        new_cube.add_aux_coord(coord, min_grid_dim)
+
+    new_cube.metadata = copy.deepcopy(src_cube.metadata)
+
+    def copy_coords(src_coords, add_method):
+        for coord in src_coords:
+            dims = src_cube.coord_dims(coord)
+            # if hasattr(coord, "mesh") or mesh_dim in dims:
+            #     continue
+            if grid_dim_x in dims or grid_dim_y in dims:
+                continue
+            # Since the mesh will be replaced by a 2D grid, dims which are
+            # beyond the mesh_dim are increased by one.
+            dims = [dim if dim < max_grid_dim else dim - 1 for dim in dims]
+            result_coord = coord.copy()
+            # Add result_coord to the owner of add_method.
+            add_method(result_coord, dims)
+
+    copy_coords(src_cube.dim_coords, new_cube.add_dim_coord)
+    copy_coords(src_cube.aux_coords, new_cube.add_aux_coord)
+
+    return new_cube
+
+
+def _regrid_rectilinear_to_unstructured__prepare(src_grid_cube, target_mesh_cube):
+    """
+    First (setup) part of 'regrid_rectilinear_to_unstructured'.
+
+    Check inputs and calculate the sparse regrid matrix and related info.
+    The 'regrid info' returned can be re-used over many 2d slices.
+
+    """
+    grid_x, grid_y = get_xy_dim_coords(src_grid_cube)
+    mesh = target_mesh_cube.mesh
+    # TODO: Improve the checking of mesh validity. Check the mesh location and
+    #  raise appropriate error messages.
+    assert mesh is not None
+    # From src_mesh_cube, fetch the mesh, and the dimension on the cube which that
+    # mesh belongs to.
+    # mesh_dim = src_mesh_cube.mesh_dim()
+    grid_x_dim = src_grid_cube.coord_dims(grid_x)[0]
+    grid_y_dim = src_grid_cube.coord_dims(grid_y)[0]
+
+    meshinfo = _mesh_to_MeshInfo(mesh)
+    gridinfo = _cube_to_GridInfo(src_grid_cube)
+
+    regridder = Regridder(gridinfo, meshinfo)
+
+    regrid_info = (grid_x_dim, grid_y_dim, grid_x, grid_y, mesh, regridder)
+
+    return regrid_info
+
+
+def _regrid_rectilinear_to_unstructured__perform(src_cube, regrid_info, mdtol):
+    """
+    Second (regrid) part of 'regrid_rectilinear_to_unstructured'.
+
+    Perform the prepared regrid calculation on a single cube.
+
+    """
+    grid_x_dim, grid_y_dim, grid_x, grid_y, mesh, regridder = regrid_info
+
+    # Perform regridding with realised data for the moment. This may be changed
+    # in future to handle src_cube.lazy_data.
+    new_data = _regrid_along_grid_dims(
+        regridder, src_cube.data, grid_x_dim, grid_y_dim, mdtol
+    )
+
+    new_cube = _create_mesh_cube(
+        new_data,
+        src_cube,
+        grid_x_dim,
+        grid_y_dim,
+        mesh,
+    )
+    return new_cube
+
+
+def regrid_rectilinear_to_unstructured(src_cube, grid_cube, mdtol=0):
+    regrid_info = _regrid_rectilinear_to_unstructured__prepare(src_cube, grid_cube)
+    result = _regrid_rectilinear_to_unstructured__perform(src_cube, regrid_info, mdtol)
+    return result
+
+
+class GridToMeshESMFRegridder:
+    """Regridder class for rectilinear to unstructured cubes."""
+
+    def __init__(self, src_mesh_cube, target_grid_cube, mdtol=1):
+        """
+        Create regridder for conversions between source grid and target mesh.
+
+        Parameters
+        ----------
+        src_grid_cube : cube
+            The unstructured iris cube providing the source grid.
+        target_grid_cube : cube
+            The rectilinear iris cube providing the target mesh.
+        mdtol : float, optional
+            Tolerance of missing data. The value returned in each element of
+            the returned array will be masked if the fraction of masked data
+            exceeds mdtol. mdtol=0 means no missing data is tolerated while
+            mdtol=1 will mean the resulting element will be masked if and only
+            if all the contributing elements of data are masked.
+            Defaults to 1.
+
+        """
+        # Missing data tolerance.
+        # Code directly copied from iris.
+        if not (0 <= mdtol <= 1):
+            msg = "Value for mdtol must be in range 0 - 1, got {}."
+            raise ValueError(msg.format(mdtol))
+        self.mdtol = mdtol
+
+        partial_regrid_info = _regrid_rectilinear_to_unstructured__prepare(
+            src_mesh_cube, target_grid_cube
+        )
+
+        # Store regrid info.
+        _, _, self.grid_x, self.grid_y, self.mesh, self.regridder = partial_regrid_info
+
+    def __call__(self, cube):
+        """
+        Regrid this cube onto the target mesh of this regridder instance.
+
+        The given cube must be defined with the same grid as the source
+        cube used to create this MeshToGridESMFRegridder instance.
+
+        Parameters
+        ----------
+        cube : cube
+            A iris.cube.Cube instance to be regridded.
+
+        Returns
+        -------
+            A cube defined with the horizontal dimensions of the target
+            and the other dimensions from this cube. The data values of
+            this cube will be converted to values on the new grid using
+            area-weighted regridding via ESMF generated weights.
+
+        """
+        grid_x, grid_y = get_xy_dim_coords(src_grid_cube)
+        assert grid_x == self.grid_x
+        assert grid_y == self.grid_y
+
+        grid_x_dim = cube.coord_dims(grid_x)[0]
+        grid_y_dim = cube.coord_dims(grid_y)[0]
+
+        regrid_info = (
+            grid_x_dim,
+            grid_y_dim,
+            self.grid_x,
+            self.grid_y,
+            self.mesh,
+            self.regridder,
+        )
+
+        return _regrid_rectilinear_to_unstructured__perform(
             cube, regrid_info, self.mdtol
         )

--- a/esmf_regrid/tests/unit/experimental/unstructured_scheme/test_GridToMeshESMFRegridder.py
+++ b/esmf_regrid/tests/unit/experimental/unstructured_scheme/test_GridToMeshESMFRegridder.py
@@ -161,6 +161,7 @@ def test_mismatched_grids():
     with pytest.raises(ValueError):
         _ = regridder(src_other)
 
+
 def test_mask_handling():
     """
     Test masked data handling for :func:`esmf_regrid.experimental.unstructured_scheme.regrid_rectilinear_to_unstructured`.

--- a/esmf_regrid/tests/unit/experimental/unstructured_scheme/test_GridToMeshESMFRegridder.py
+++ b/esmf_regrid/tests/unit/experimental/unstructured_scheme/test_GridToMeshESMFRegridder.py
@@ -13,7 +13,6 @@ from esmf_regrid.tests.unit.experimental.unstructured_scheme.test__cube_to_GridI
 )
 from esmf_regrid.tests.unit.experimental.unstructured_scheme.test__regrid_unstructured_to_rectilinear__prepare import (
     _flat_mesh_cube,
-    _full_mesh,
 )
 
 

--- a/esmf_regrid/tests/unit/experimental/unstructured_scheme/test_GridToMeshESMFRegridder.py
+++ b/esmf_regrid/tests/unit/experimental/unstructured_scheme/test_GridToMeshESMFRegridder.py
@@ -165,6 +165,8 @@ def test_mismatched_grids():
 def test_mask_handling():
     """
     Test masked data handling for :func:`esmf_regrid.experimental.unstructured_scheme.GridToMeshESMFRegridder`.
+
+    Tests masked data handling for multiple valid values for mdtol.
     """
     tgt = _flat_mesh_cube()
 

--- a/esmf_regrid/tests/unit/experimental/unstructured_scheme/test_GridToMeshESMFRegridder.py
+++ b/esmf_regrid/tests/unit/experimental/unstructured_scheme/test_GridToMeshESMFRegridder.py
@@ -143,9 +143,7 @@ def test_mismatched_grids():
     cube whose grid does not match with the one used when initialising
     the regridder.
     """
-
     tgt = _flat_mesh_cube()
-
     n_lons = 6
     n_lats = 5
     lon_bounds = (-180, 180)

--- a/esmf_regrid/tests/unit/experimental/unstructured_scheme/test_GridToMeshESMFRegridder.py
+++ b/esmf_regrid/tests/unit/experimental/unstructured_scheme/test_GridToMeshESMFRegridder.py
@@ -133,3 +133,31 @@ def test_invalid_mdtol():
         _ = GridToMeshESMFRegridder(src, tgt, mdtol=2)
     with pytest.raises(ValueError):
         _ = GridToMeshESMFRegridder(src, tgt, mdtol=-1)
+
+
+def test_mismatched_grids():
+    """
+    Test error handling in calling of :func:`esmf_regrid.experimental.unstructured_scheme.GridToMeshESMFRegridder`.
+
+    Checks that an error is raised when the regridder is called with a
+    cube whose grid does not match with the one used when initialising
+    the regridder.
+    """
+
+    tgt = _flat_mesh_cube()
+
+    n_lons = 6
+    n_lats = 5
+    lon_bounds = (-180, 180)
+    lat_bounds = (-90, 90)
+    src = _grid_cube(n_lons, n_lats, lon_bounds, lat_bounds, circular=True)
+
+    regridder = GridToMeshESMFRegridder(src, tgt)
+
+    n_lons_other = 3
+    n_lats_other = 10
+    src_other = _grid_cube(
+        n_lons_other, n_lats_other, lon_bounds, lat_bounds, circular=True
+    )
+    with pytest.raises(ValueError):
+        _ = regridder(src_other)

--- a/esmf_regrid/tests/unit/experimental/unstructured_scheme/test_GridToMeshESMFRegridder.py
+++ b/esmf_regrid/tests/unit/experimental/unstructured_scheme/test_GridToMeshESMFRegridder.py
@@ -1,0 +1,136 @@
+"""Unit tests for :func:`esmf_regrid.experimental.unstructured_scheme.GridToMeshESMFRegridder`."""
+
+from iris.coords import AuxCoord, DimCoord
+from iris.cube import Cube
+import numpy as np
+import pytest
+
+from esmf_regrid.experimental.unstructured_scheme import (
+    GridToMeshESMFRegridder,
+)
+from esmf_regrid.tests.unit.experimental.unstructured_scheme.test__cube_to_GridInfo import (
+    _grid_cube,
+)
+from esmf_regrid.tests.unit.experimental.unstructured_scheme.test__regrid_unstructured_to_rectilinear__prepare import (
+    _flat_mesh_cube,
+    _full_mesh,
+)
+
+
+def test_flat_cubes():
+    """
+    Basic test for :func:`esmf_regrid.experimental.unstructured_scheme.GridToMeshESMFRegridder`.
+
+    Tests with flat cubes as input (a 2D grid cube and a 1D mesh cube).
+    """
+    tgt = _flat_mesh_cube()
+
+    n_lons = 6
+    n_lats = 5
+    lon_bounds = (-180, 180)
+    lat_bounds = (-90, 90)
+    src = _grid_cube(n_lons, n_lats, lon_bounds, lat_bounds, circular=True)
+    # Ensure data in the target grid is different to the expected data.
+    # i.e. target grid data is all zero, expected data is all one
+    tgt.data[:] = 0
+
+    def _add_metadata(cube):
+        result = cube.copy()
+        result.units = "K"
+        result.attributes = {"a": 1}
+        result.standard_name = "air_temperature"
+        scalar_height = AuxCoord([5], units="m", standard_name="height")
+        scalar_time = DimCoord([10], units="s", standard_name="time")
+        result.add_aux_coord(scalar_height)
+        result.add_aux_coord(scalar_time)
+        return result
+
+    src = _add_metadata(src)
+    src.data[:] = 1  # Ensure all data in the source is one.
+    regridder = GridToMeshESMFRegridder(src, tgt)
+    result = regridder(src)
+    src_T = src.copy()
+    src_T.transpose()
+    result_transposed = regridder(src_T)
+
+    expected_data = np.ones([n_lats, n_lons])
+    expected_cube = _add_metadata(tgt)
+
+    # Lenient check for data.
+    assert np.allclose(expected_data, result.data)
+    assert np.allclose(expected_data, result_transposed.data)
+
+    # Check metadata and scalar coords.
+    expected_cube.data = result.data
+    assert expected_cube == result
+    expected_cube.data = result_transposed.data
+    assert expected_cube == result_transposed
+
+
+def test_multidim_cubes():
+    """
+    Test for :func:`esmf_regrid.experimental.unstructured_scheme.regrid_rectilinear_to_unstructured`.
+
+    Tests with multidimensional cubes. The source cube contains
+    coordinates on the dimensions before and after the grid dimensions.
+    """
+    tgt = _flat_mesh_cube()
+    mesh = tgt.mesh
+    mesh_length = mesh.connectivity(contains_face=True).shape[0]
+    n_lons = 6
+    n_lats = 5
+    lon_bounds = (-180, 180)
+    lat_bounds = (-90, 90)
+    grid = _grid_cube(n_lons, n_lats, lon_bounds, lat_bounds, circular=True)
+
+    h = 2
+    t = 3
+    height = DimCoord(np.arange(h), standard_name="height")
+    time = DimCoord(np.arange(t), standard_name="time")
+
+    src_data = np.empty([t, n_lats, n_lons, h])
+    src_data[:] = np.arange(t * h).reshape([t, h])[:, np.newaxis, np.newaxis, :]
+    cube = Cube(src_data)
+    cube.add_dim_coord(grid.coord("latitude"), 1)
+    cube.add_dim_coord(grid.coord("longitude"), 2)
+    cube.add_dim_coord(time, 0)
+    cube.add_dim_coord(height, 3)
+
+    regridder = GridToMeshESMFRegridder(grid, tgt)
+    result = regridder(cube)
+
+    # Lenient check for data.
+    expected_data = np.empty([t, mesh_length, h])
+    expected_data[:] = np.arange(t * h).reshape(t, h)[:, np.newaxis, :]
+    assert np.allclose(expected_data, result.data)
+
+    mesh_coord_x, mesh_coord_y = mesh.to_MeshCoords("face")
+    expected_cube = Cube(expected_data)
+    expected_cube.add_dim_coord(time, 0)
+    expected_cube.add_aux_coord(mesh_coord_x, 1)
+    expected_cube.add_aux_coord(mesh_coord_y, 1)
+    expected_cube.add_dim_coord(height, 2)
+
+    # Check metadata and scalar coords.
+    result.data = expected_data
+    assert expected_cube == result
+
+
+def test_invalid_mdtol():
+    """
+    Test initialisation of :func:`esmf_regrid.experimental.unstructured_scheme.GridToMeshESMFRegridder`.
+
+    Checks that an error is raised when mdtol is out of range.
+    """
+    tgt = _flat_mesh_cube()
+
+    n_lons = 6
+    n_lats = 5
+    lon_bounds = (-180, 180)
+    lat_bounds = (-90, 90)
+    src = _grid_cube(n_lons, n_lats, lon_bounds, lat_bounds, circular=True)
+
+    with pytest.raises(ValueError):
+        _ = GridToMeshESMFRegridder(src, tgt, mdtol=2)
+    with pytest.raises(ValueError):
+        _ = GridToMeshESMFRegridder(src, tgt, mdtol=-1)

--- a/esmf_regrid/tests/unit/experimental/unstructured_scheme/test_GridToMeshESMFRegridder.py
+++ b/esmf_regrid/tests/unit/experimental/unstructured_scheme/test_GridToMeshESMFRegridder.py
@@ -164,7 +164,7 @@ def test_mismatched_grids():
 
 def test_mask_handling():
     """
-    Test masked data handling for :func:`esmf_regrid.experimental.unstructured_scheme.regrid_rectilinear_to_unstructured`.
+    Test masked data handling for :func:`esmf_regrid.experimental.unstructured_scheme.GridToMeshESMFRegridder`.
     """
     tgt = _flat_mesh_cube()
 
@@ -182,9 +182,9 @@ def test_mask_handling():
     regridder_0 = GridToMeshESMFRegridder(src, tgt, mdtol=0)
     regridder_05 = GridToMeshESMFRegridder(src, tgt, mdtol=0.05)
     regridder_1 = GridToMeshESMFRegridder(src, tgt, mdtol=1)
-    result_0 = regridder_0(src, tgt)
-    result_05 = regridder_05(src, tgt)
-    result_1 = regridder_1(src, tgt)
+    result_0 = regridder_0(src)
+    result_05 = regridder_05(src)
+    result_1 = regridder_1(src)
 
     expected_data = np.ones(tgt.shape)
     expected_0 = ma.array(expected_data)

--- a/esmf_regrid/tests/unit/experimental/unstructured_scheme/test_regrid_rectilinear_to_unstructured.py
+++ b/esmf_regrid/tests/unit/experimental/unstructured_scheme/test_regrid_rectilinear_to_unstructured.py
@@ -134,7 +134,7 @@ def test_multidim_cubes():
 def test_mask_handling():
     """
     Test masked data handling for :func:`esmf_regrid.experimental.unstructured_scheme.regrid_rectilinear_to_unstructured`.
-    
+
     Tests masked data handling for multiple valid values for mdtol.
     """
     tgt = _flat_mesh_cube()

--- a/esmf_regrid/tests/unit/experimental/unstructured_scheme/test_regrid_rectilinear_to_unstructured.py
+++ b/esmf_regrid/tests/unit/experimental/unstructured_scheme/test_regrid_rectilinear_to_unstructured.py
@@ -12,7 +12,6 @@ from esmf_regrid.tests.unit.experimental.unstructured_scheme.test__cube_to_GridI
 )
 from esmf_regrid.tests.unit.experimental.unstructured_scheme.test__regrid_unstructured_to_rectilinear__prepare import (
     _flat_mesh_cube,
-    _full_mesh,
 )
 
 

--- a/esmf_regrid/tests/unit/experimental/unstructured_scheme/test_regrid_rectilinear_to_unstructured.py
+++ b/esmf_regrid/tests/unit/experimental/unstructured_scheme/test_regrid_rectilinear_to_unstructured.py
@@ -86,7 +86,7 @@ def test_multidim_cubes():
     height = DimCoord(np.arange(h), standard_name="height")
     pressure = DimCoord(np.arange(p), standard_name="air_pressure")
     time = DimCoord(np.arange(t), standard_name="time")
-    spanning = AuxCoord(np.ones([h, p, t]), long_name="spanning dim")
+    spanning = AuxCoord(np.ones([t, p, h]), long_name="spanning dim")
     ignore = AuxCoord(np.ones([n_lats, t]), long_name="ignore")
 
     src_data = np.empty([t, n_lats, p, n_lons, h])

--- a/esmf_regrid/tests/unit/experimental/unstructured_scheme/test_regrid_rectilinear_to_unstructured.py
+++ b/esmf_regrid/tests/unit/experimental/unstructured_scheme/test_regrid_rectilinear_to_unstructured.py
@@ -87,7 +87,7 @@ def test_multidim_cubes():
     pressure = DimCoord(np.arange(p), standard_name="air_pressure")
     time = DimCoord(np.arange(t), standard_name="time")
     spanning = AuxCoord(np.ones([t, p, h]), long_name="spanning dim")
-    ignore = AuxCoord(np.ones([n_lats, t]), long_name="ignore")
+    ignore = AuxCoord(np.ones([n_lats, h]), long_name="ignore")
 
     src_data = np.empty([t, n_lats, p, n_lons, h])
     src_data[:] = np.arange(t * p * h).reshape([t, p, h])[

--- a/esmf_regrid/tests/unit/experimental/unstructured_scheme/test_regrid_rectilinear_to_unstructured.py
+++ b/esmf_regrid/tests/unit/experimental/unstructured_scheme/test_regrid_rectilinear_to_unstructured.py
@@ -1,0 +1,113 @@
+"""Unit tests for :func:`esmf_regrid.experimental.unstructured_scheme.regrid_rectilinear_to_unstructured`."""
+
+from iris.coords import AuxCoord, DimCoord
+from iris.cube import Cube
+import numpy as np
+
+from esmf_regrid.experimental.unstructured_scheme import (
+    regrid_rectilinear_to_unstructured,
+)
+from esmf_regrid.tests.unit.experimental.unstructured_scheme.test__cube_to_GridInfo import (
+    _grid_cube,
+)
+from esmf_regrid.tests.unit.experimental.unstructured_scheme.test__regrid_unstructured_to_rectilinear__prepare import (
+    _flat_mesh_cube,
+    _full_mesh,
+)
+
+
+def test_flat_cubes():
+    """
+    Basic test for :func:`esmf_regrid.experimental.unstructured_scheme.regrid_rectilinear_to_unstructured`.
+
+    Tests with flat cubes as input (a 2D grid cube and a 1D mesh cube).
+    """
+    tgt = _flat_mesh_cube()
+
+    n_lons = 6
+    n_lats = 5
+    lon_bounds = (-180, 180)
+    lat_bounds = (-90, 90)
+    src = _grid_cube(n_lons, n_lats, lon_bounds, lat_bounds, circular=True)
+    # Ensure data in the target grid is different to the expected data.
+    # i.e. target grid data is all zero, expected data is all one
+    tgt.data[:] = 0
+
+    def _add_metadata(cube):
+        result = cube.copy()
+        result.units = "K"
+        result.attributes = {"a": 1}
+        result.standard_name = "air_temperature"
+        scalar_height = AuxCoord([5], units="m", standard_name="height")
+        scalar_time = DimCoord([10], units="s", standard_name="time")
+        result.add_aux_coord(scalar_height)
+        result.add_aux_coord(scalar_time)
+        return result
+
+    src = _add_metadata(src)
+    src.data[:] = 1  # Ensure all data in the source is one.
+    result = regrid_rectilinear_to_unstructured(src, tgt)
+    src_T = src.copy()
+    src_T.transpose()
+    result_transposed = regrid_rectilinear_to_unstructured(src_T, tgt)
+
+    expected_data = np.ones([n_lats, n_lons])
+    expected_cube = _add_metadata(tgt)
+
+    # Lenient check for data.
+    assert np.allclose(expected_data, result.data)
+    assert np.allclose(expected_data, result_transposed.data)
+
+    # Check metadata and scalar coords.
+    expected_cube.data = result.data
+    assert expected_cube == result
+    expected_cube.data = result_transposed.data
+    assert expected_cube == result_transposed
+
+
+def test_multidim_cubes():
+    """
+    Test for :func:`esmf_regrid.experimental.unstructured_scheme.regrid_rectilinear_to_unstructured`.
+
+    Tests with multidimensional cubes. The source cube contains
+    coordinates on the dimensions before and after the grid dimensions.
+    """
+    tgt = _flat_mesh_cube()
+    mesh = tgt.mesh
+    mesh_length = mesh.connectivity(contains_face=True).shape[0]
+    n_lons = 6
+    n_lats = 5
+    lon_bounds = (-180, 180)
+    lat_bounds = (-90, 90)
+    grid = _grid_cube(n_lons, n_lats, lon_bounds, lat_bounds, circular=True)
+
+    h = 2
+    t = 3
+    height = DimCoord(np.arange(h), standard_name="height")
+    time = DimCoord(np.arange(t), standard_name="time")
+
+    src_data = np.empty([t, n_lats, n_lons, h])
+    src_data[:] = np.arange(t * h).reshape([t, h])[:, np.newaxis, np.newaxis, :]
+    cube = Cube(src_data)
+    cube.add_dim_coord(grid.coord("latitude"), 1)
+    cube.add_dim_coord(grid.coord("longitude"), 2)
+    cube.add_dim_coord(time, 0)
+    cube.add_dim_coord(height, 3)
+
+    result = regrid_rectilinear_to_unstructured(cube, tgt)
+
+    # Lenient check for data.
+    expected_data = np.empty([t, mesh_length, h])
+    expected_data[:] = np.arange(t * h).reshape(t, h)[:, np.newaxis, :]
+    assert np.allclose(expected_data, result.data)
+
+    mesh_coord_x, mesh_coord_y = mesh.to_MeshCoords("face")
+    expected_cube = Cube(expected_data)
+    expected_cube.add_dim_coord(time, 0)
+    expected_cube.add_aux_coord(mesh_coord_x, 1)
+    expected_cube.add_aux_coord(mesh_coord_y, 1)
+    expected_cube.add_dim_coord(height, 2)
+
+    # Check metadata and scalar coords.
+    result.data = expected_data
+    assert expected_cube == result

--- a/esmf_regrid/tests/unit/experimental/unstructured_scheme/test_regrid_rectilinear_to_unstructured.py
+++ b/esmf_regrid/tests/unit/experimental/unstructured_scheme/test_regrid_rectilinear_to_unstructured.py
@@ -86,6 +86,8 @@ def test_multidim_cubes():
     height = DimCoord(np.arange(h), standard_name="height")
     pressure = DimCoord(np.arange(p), standard_name="air_pressure")
     time = DimCoord(np.arange(t), standard_name="time")
+    spanning = AuxCoord(np.ones([h, p, t]), long_name="spanning dim")
+    ignore = AuxCoord(np.ones[n_lats, t], long_name="ignore")
 
     src_data = np.empty([t, n_lats, p, n_lons, h])
     src_data[:] = np.arange(t * p * h).reshape([t, p, h])[
@@ -97,6 +99,8 @@ def test_multidim_cubes():
     cube.add_dim_coord(time, 0)
     cube.add_dim_coord(pressure, 2)
     cube.add_dim_coord(height, 4)
+    cube.add_aux_coord(spanning, [0, 2, 4])
+    cube.add_aux_coord(ignore, [1, 4])
 
     result = regrid_rectilinear_to_unstructured(cube, tgt)
 
@@ -117,6 +121,7 @@ def test_multidim_cubes():
     expected_cube.add_aux_coord(mesh_coord_y, 1)
     expected_cube.add_dim_coord(pressure, 2)
     expected_cube.add_dim_coord(height, 3)
+    expected_cube.add_aux_coord(spanning, [0, 2, 3])
 
     # Check metadata and scalar coords.
     result.data = expected_data

--- a/esmf_regrid/tests/unit/experimental/unstructured_scheme/test_regrid_rectilinear_to_unstructured.py
+++ b/esmf_regrid/tests/unit/experimental/unstructured_scheme/test_regrid_rectilinear_to_unstructured.py
@@ -87,7 +87,7 @@ def test_multidim_cubes():
     pressure = DimCoord(np.arange(p), standard_name="air_pressure")
     time = DimCoord(np.arange(t), standard_name="time")
     spanning = AuxCoord(np.ones([h, p, t]), long_name="spanning dim")
-    ignore = AuxCoord(np.ones[n_lats, t], long_name="ignore")
+    ignore = AuxCoord(np.ones([n_lats, t]), long_name="ignore")
 
     src_data = np.empty([t, n_lats, p, n_lons, h])
     src_data[:] = np.arange(t * p * h).reshape([t, p, h])[

--- a/esmf_regrid/tests/unit/experimental/unstructured_scheme/test_regrid_rectilinear_to_unstructured.py
+++ b/esmf_regrid/tests/unit/experimental/unstructured_scheme/test_regrid_rectilinear_to_unstructured.py
@@ -134,6 +134,8 @@ def test_multidim_cubes():
 def test_mask_handling():
     """
     Test masked data handling for :func:`esmf_regrid.experimental.unstructured_scheme.regrid_rectilinear_to_unstructured`.
+    
+    Tests masked data handling for multiple valid values for mdtol.
     """
     tgt = _flat_mesh_cube()
 


### PR DESCRIPTION
Adds a scheme for regridding from a cube with a grid to a target cube with a mesh. Ultimateley, the regridding schemes may be unified to one which identifies the whether the source and target have a grid or a mesh in them. This scheme adds the third of four possible combinations with only mesh to mesh regridders remaining to be added.