### PR TITLE
Add regridding benchmark

### DIFF
--- a/benchmarks/benchmarks/ci/esmf_regridder.py
+++ b/benchmarks/benchmarks/ci/esmf_regridder.py
@@ -72,7 +72,9 @@ class TimeRegridding:
             coord_system=coord_system_src,
         )
         tgt = _grid_cube(n_lons_tgt, n_lats_tgt, lon_bounds, lat_bounds)
-        src_data = np.arange(n_lats_src * n_lons_src * h).reshape([n_lats_src, n_lons_src, h])
+        src_data = np.arange(n_lats_src * n_lons_src * h).reshape(
+            [n_lats_src, n_lons_src, h]
+        )
         src = Cube(src_data)
         src.add_dim_coord(grid.coord("latitude"), 0)
         src.add_dim_coord(grid.coord("longitude"), 1)

--- a/benchmarks/benchmarks/ci/esmf_regridder.py
+++ b/benchmarks/benchmarks/ci/esmf_regridder.py
@@ -2,6 +2,7 @@
 
 import numpy as np
 from iris.coord_systems import RotatedGeogCS
+from iris.cube import Cube
 
 from esmf_regrid.esmf_regridder import GridInfo
 from esmf_regrid.schemes import ESMFAreaWeightedRegridder
@@ -52,6 +53,7 @@ class TimeRegridding:
         n_lats_src = 40
         n_lons_tgt = 20
         n_lats_tgt = 40
+        h = 100
         if type == "large source":
             n_lons_src = 100
             n_lats_src = 200
@@ -62,7 +64,7 @@ class TimeRegridding:
             coord_system_src = RotatedGeogCS(0, 90, 90)
         else:
             coord_system_src = None
-        src = _grid_cube(
+        grid = _grid_cube(
             n_lons_src,
             n_lats_src,
             lon_bounds,
@@ -70,6 +72,10 @@ class TimeRegridding:
             coord_system=coord_system_src,
         )
         tgt = _grid_cube(n_lons_tgt, n_lats_tgt, lon_bounds, lat_bounds)
+        src_data = np.arange(n_lats_src * n_lons_src * h).reshape([n_lats_src, n_lons_src, h])
+        src = Cube(src_data)
+        src.add_dim_coord(grid.coord("latitude"), 0)
+        src.add_dim_coord(grid.coord("longitude"), 1)
         self.regridder = ESMFAreaWeightedRegridder(src, tgt)
         self.src = src
 

--- a/benchmarks/benchmarks/ci/esmf_regridder.py
+++ b/benchmarks/benchmarks/ci/esmf_regridder.py
@@ -45,6 +45,7 @@ class TimeGridInfo:
 
 class TimeRegridding:
     params = ["similar", "large source", "large target", "mixed"]
+    param_names = ["source/target difference"]
 
     def setup(self, type):
         lon_bounds = (-180, 180)


### PR DESCRIPTION
Adds benchmarks for the performing of regridding (after initialisation of a regridder). This is with a view to measuring the performance of different regridding solutions (i.e. sparse vs scipy.sparse). The benchmark is written to include cases involving higher to lower resolution, lower to higher, similar resolutions and a case where parts of the grid are high to low res and other parts are low to high res due to a rotated pole.