### PR TITLE
Change iris source to main

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -32,7 +32,7 @@ env:
   # Conda packages to be installed.
   CONDA_CACHE_PACKAGES: "nox pip pyyaml"
   # Use specific custom iris source feature branch.
-  IRIS_SOURCE: "github:mesh-data-model"
+  IRIS_SOURCE: "github:main"
   # Git commit hash for iris test data.
   IRIS_TEST_DATA_VERSION: "2.2"
   # Base directory for the iris-test-data.


### PR DESCRIPTION
Since the iris feature branch `mesh-data-model` has been merged into main (https://github.com/SciTools/iris/pull/4313) the iris source for our own feature branch should now change to main