### PR TITLE
Add performance tests

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -11,8 +11,8 @@
 #
 container:
   image: python:3.8
-  cpu: 4
-  memory: 6G
+  cpu: 2
+  memory: 4G
 
 env:
   # Skip specific tasks by name. Set to a non-empty string to skip.

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -12,7 +12,7 @@
 container:
   image: python:3.8
   cpu: 2
-  memory: 4G
+  memory: 6G
 
 env:
   # Skip specific tasks by name. Set to a non-empty string to skip.

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -11,7 +11,7 @@
 #
 container:
   image: python:3.8
-  cpu: 2
+  cpu: 4
   memory: 6G
 
 env:

--- a/benchmarks/benchmarks/ci/esmf_regridder.py
+++ b/benchmarks/benchmarks/ci/esmf_regridder.py
@@ -114,7 +114,12 @@ class TimeRegridding(MultiGridCompare):
         src.add_dim_coord(grid.coord("latitude"), 0)
         src.add_dim_coord(grid.coord("longitude"), 1)
         self.regridder = ESMFAreaWeightedRegridder(src, tgt)
+        self.regrid_class = ESMFAreaWeightedRegridder
         self.src = src
+        self.tgt = tgt
+
+    def time_prepare_regridding(self, type):
+        _ = self.regrid_class(self.src, self.tgt)
 
     def time_perform_regridding(self, type):
         _ = self.regridder(self.src)
@@ -203,7 +208,9 @@ class TimeMeshToGridRegridding(TimeRegridding):
         src.add_aux_coord(mesh_coord_x, 0)
         src.add_aux_coord(mesh_coord_y, 0)
         self.regridder = MeshToGridESMFRegridder(src, tgt)
+        self.regrid_class = MeshToGridESMFRegridder
         self.src = src
+        self.tgt = tgt
 
 
 @disable_repeat_between_setup
@@ -300,7 +307,9 @@ class TimeGridToMeshRegridding(TimeRegridding):
         tgt.add_aux_coord(mesh_coord_x, 0)
         tgt.add_aux_coord(mesh_coord_y, 0)
         self.regridder = GridToMeshESMFRegridder(src, tgt)
+        self.regrid_class = GridToMeshESMFRegridder
         self.src = src
+        self.tgt = tgt
 
 
 @disable_repeat_between_setup

--- a/benchmarks/benchmarks/ci/esmf_regridder.py
+++ b/benchmarks/benchmarks/ci/esmf_regridder.py
@@ -113,8 +113,8 @@ class TimeRegridding(MultiGridCompare):
         src = Cube(src_data)
         src.add_dim_coord(grid.coord("latitude"), 0)
         src.add_dim_coord(grid.coord("longitude"), 1)
-        self.regridder = ESMFAreaWeightedRegridder(src, tgt)
         self.regrid_class = ESMFAreaWeightedRegridder
+        self.regridder = self.regrid_class(src, tgt)
         self.src = src
         self.tgt = tgt
 
@@ -207,8 +207,8 @@ class TimeMeshToGridRegridding(TimeRegridding):
         mesh_coord_x, mesh_coord_y = mesh.to_MeshCoords("face")
         src.add_aux_coord(mesh_coord_x, 0)
         src.add_aux_coord(mesh_coord_y, 0)
-        self.regridder = MeshToGridESMFRegridder(src, tgt)
         self.regrid_class = MeshToGridESMFRegridder
+        self.regridder = self.regrid_class(src, tgt)
         self.src = src
         self.tgt = tgt
 
@@ -306,8 +306,8 @@ class TimeGridToMeshRegridding(TimeRegridding):
         mesh_coord_x, mesh_coord_y = mesh.to_MeshCoords("face")
         tgt.add_aux_coord(mesh_coord_x, 0)
         tgt.add_aux_coord(mesh_coord_y, 0)
-        self.regridder = GridToMeshESMFRegridder(src, tgt)
         self.regrid_class = GridToMeshESMFRegridder
+        self.regridder = self.regrid_class(src, tgt)
         self.src = src
         self.tgt = tgt
 

--- a/benchmarks/benchmarks/long/esmf_regridder.py
+++ b/benchmarks/benchmarks/long/esmf_regridder.py
@@ -17,7 +17,7 @@ from esmf_regrid.tests.unit.schemes.test__cube_to_GridInfo import _grid_cube
 
 
 class PrepareScalabilityGridToGrid:
-    params = [50, 100, 500, 1000, 2000]
+    params = [50, 100, 200, 400, 600, 800, 1000, 2000]
     height = 100
     regridder = ESMFAreaWeightedRegridder
 
@@ -75,9 +75,10 @@ class PrepareScalabilityGridToMesh(PrepareScalabilityGridToGrid):
 
 @disable_repeat_between_setup
 class PerformScalabilityGridToGrid:
-    params = [10, 100, 1000, 10000]
+    params = [100, 200, 400, 600, 800, 1000]
     grid_size = 500
-    chunk_size = [grid_size / 2, grid_size / 2, 10]
+    target_grid_size = 51
+    chunk_size = [int(grid_size / 2), int(grid_size / 2), 10]
     regridder = ESMFAreaWeightedRegridder
 
     def src_cube(self, height):
@@ -97,7 +98,7 @@ class PerformScalabilityGridToGrid:
         lon_bounds = (-180, 180)
         lat_bounds = (-90, 90)
         grid = _grid_cube(
-            self.grid_size / 10 + 1, self.grid_size / 10 + 1, lon_bounds, lat_bounds
+            self.target_grid_size, self.target_grid_size, lon_bounds, lat_bounds
         )
         return grid
 
@@ -168,8 +169,8 @@ class PerformScalabilityGridToMesh(PerformScalabilityGridToGrid):
             _gridlike_mesh,
         )
 
-        tgt = Cube(np.ones([(self.grid_size / 10 + 1) * (self.grid_size / 10 + 1)]))
-        mesh = _gridlike_mesh(self.grid_size / 10 + 1, self.grid_size / 10 + 1)
+        tgt = Cube(np.ones([self.target_grid_size * self.target_grid_size]))
+        mesh = _gridlike_mesh(self.target_grid_size, self.target_grid_size)
         mesh_coord_x, mesh_coord_y = mesh.to_MeshCoords("face")
         tgt.add_aux_coord(mesh_coord_x, 0)
         tgt.add_aux_coord(mesh_coord_y, 0)

--- a/benchmarks/benchmarks/long/esmf_regridder.py
+++ b/benchmarks/benchmarks/long/esmf_regridder.py
@@ -134,7 +134,12 @@ class PerformScalabilityGridToGrid:
 
 class PerformScalabilityMeshToGrid(PerformScalabilityGridToGrid):
     regridder = MeshToGridESMFRegridder
-    chunk_size = [grid_size / 2 * grid_size / 2, 10]
+    chunk_size = [
+        PerformScalabilityGridToGrid.grid_size
+        * PerformScalabilityGridToGrid.grid_size
+        / 4,
+        10,
+    ]
 
     def src_cube(self, height, chunk_size):
         data = da.ones(
@@ -157,7 +162,6 @@ class PerformScalabilityMeshToGrid(PerformScalabilityGridToGrid):
 
 class PerformScalabilityGridToMesh(PerformScalabilityGridToGrid):
     regridder = GridToMeshESMFRegridder
-    chunk_size = [grid_size / 2 * grid_size / 2, 10]
 
     def tgt_cube(self):
         from esmf_regrid.tests.unit.experimental.unstructured_scheme.test__mesh_to_MeshInfo import (

--- a/benchmarks/benchmarks/long/esmf_regridder.py
+++ b/benchmarks/benchmarks/long/esmf_regridder.py
@@ -111,6 +111,8 @@ class PerformScalabilityGridToGrid:
         file = str(SYNTH_DATA_DIR.joinpath(self.file_name))
 
         src = self.src_cube(max(self.params))
+        # While iris is not able to save meshes, we add these after loading. 
+        # TODO: change this back after iris allows mesh saving.
         iris.save(src, file, chunksizes=self.chunk_size)
         loaded_src = iris.load_cube(file)
         loaded_src = self.add_src_metadata(loaded_src)

--- a/benchmarks/benchmarks/long/esmf_regridder.py
+++ b/benchmarks/benchmarks/long/esmf_regridder.py
@@ -1,0 +1,170 @@
+"""Slower benchmarks for :mod:`esmf_regrid.esmf_regridder`."""
+
+import numpy as np
+import dask.array as da
+import iris
+from iris.coord_systems import RotatedGeogCS
+from iris.cube import Cube
+
+from benchmarks import disable_repeat_between_setup
+from esmf_regrid.esmf_regridder import GridInfo
+from esmf_regrid.experimental.unstructured_scheme import (
+    GridToMeshESMFRegridder,
+    MeshToGridESMFRegridder,
+)
+from esmf_regrid.schemes import ESMFAreaWeightedRegridder
+from esmf_regrid.tests.unit.schemes.test__cube_to_GridInfo import _grid_cube
+
+
+class PrepareScalabilityGridToGrid:
+    params = [50, 100, 500, 1000, 2000]
+    height = 100
+    regridder = ESMFAreaWeightedRegridder
+
+    def src_cube(self, n):
+        src = _grid_cube(n, n, lon_bounds, lat_bounds)
+        return src
+
+    def tgt_cube(self, n):
+        lon_bounds = (-180, 180)
+        lat_bounds = (-90, 90)
+        grid = _grid_cube(n + 1, n + 1, lon_bounds, lat_bounds)
+        return grid
+
+    def setup(self, n):
+        self.src = self.src_cube(n)
+        self.tgt = self.tgt_cube(n)
+
+    def time_prepare(self, n):
+        rg = self.regridder(self.src, self.tgt)
+
+
+class PrepareScalabilityMeshToGrid(PrepareScalabilityGridToGrid):
+    regridder = MeshToGridESMFRegridder
+
+    def src_cube(self, n):
+        from esmf_regrid.tests.unit.experimental.unstructured_scheme.test__mesh_to_MeshInfo import (
+            _gridlike_mesh,
+        )
+
+        src = Cube(np.ones([n * n]))
+        mesh = _gridlike_mesh(n, n)
+        mesh_coord_x, mesh_coord_y = mesh.to_MeshCoords("face")
+        src.add_aux_coord(mesh_coord_x, 0)
+        src.add_aux_coord(mesh_coord_y, 0)
+        return src
+
+
+class PrepareScalabilityGridToMesh(PrepareScalabilityGridToGrid):
+    regridder = GridToMeshESMFRegridder
+
+    def tgt_cube(self, n):
+        from esmf_regrid.tests.unit.experimental.unstructured_scheme.test__mesh_to_MeshInfo import (
+            _gridlike_mesh,
+        )
+
+        tgt = Cube(np.ones([(n + 1) * (n + 1)]))
+        mesh = _gridlike_mesh(n + 1, n + 1)
+        mesh_coord_x, mesh_coord_y = mesh.to_MeshCoords("face")
+        tgt.add_aux_coord(mesh_coord_x, 0)
+        tgt.add_aux_coord(mesh_coord_y, 0)
+        return tgt
+
+
+@disable_repeat_between_setup
+class PerformScalabilityGridToGrid:
+    params = [10, 100, 1000, 10000]
+    grid_size = 500
+    chunk_size = [grid_size / 2, grid_size / 2, 10]
+    regridder = ESMFAreaWeightedRegridder
+
+    def src_cube(self, height):
+        data = da.ones([self.grid_size, self.grid_size, height], chunks=self.chunk_size)
+        src = Cube(data)
+        return src
+
+    def add_src_metadata(self, cube):
+        lon_bounds = (-180, 180)
+        lat_bounds = (-90, 90)
+        grid = _grid_cube(self.grid_size, self.grid_size, lon_bounds, lat_bounds)
+        cube.add_dim_coord(grid.coord("latitude"), 0)
+        cube.add_dim_coord(grid.coord("longitude"), 1)
+        return cube
+
+    def tgt_cube(self):
+        lon_bounds = (-180, 180)
+        lat_bounds = (-90, 90)
+        grid = _grid_cube(
+            self.grid_size / 10 + 1, self.grid_size / 10 + 1, lon_bounds, lat_bounds
+        )
+        return grid
+
+    def setup_cache(self, height):
+        SYNTH_DATA_DIR = Path().cwd() / "tmp_data"
+        SYNTH_DATA_DIR.mkdir(exist_ok=True)
+        file = str(SYNTH_DATA_DIR.joinpath("chunked_cube.nc"))
+
+        src = self.src_cube(height)
+        iris.save(src, file, chunksizes=self.chunk_size)
+        loaded_src = iris.load_cube(file)
+        loaded_src = self.add_src_metadata(loaded_src)
+        tgt = self.tgt_cube()
+        rg = self.regridder(loaded_src, tgt)
+        return rg, file
+
+    def setup(self, cache, height):
+        regridder, file = cache
+        self.src = iris.load_cube(file)
+        # Realise data.
+        self.src.data
+        cube = iris.load_cube(file)
+        self.result = regridder(cube)
+
+    def time_perform(self, cache, height):
+        assert not self.src.has_lazy_data()
+        rg, _ = cache
+        _ = rg(self.src)
+
+    def time_lazy_perform(self, cache, height):
+        assert self.result.has_lazy_data()
+        _ = self.result.data
+
+
+class PerformScalabilityMeshToGrid(PerformScalabilityGridToGrid):
+    regridder = MeshToGridESMFRegridder
+    chunk_size = [grid_size / 2 * grid_size / 2, 10]
+
+    def src_cube(self, height, chunk_size):
+        data = da.ones(
+            [self.grid_size * self.grid_size, height], chunks=self.chunk_size
+        )
+        src = Cube(data)
+        return src
+
+    def add_src_metadata(self, cube):
+        from esmf_regrid.tests.unit.experimental.unstructured_scheme.test__mesh_to_MeshInfo import (
+            _gridlike_mesh,
+        )
+
+        mesh = _gridlike_mesh(grid_size, grid_size)
+        mesh_coord_x, mesh_coord_y = mesh.to_MeshCoords("face")
+        cube.add_aux_coord(mesh_coord_x, 0)
+        cube.add_aux_coord(mesh_coord_y, 0)
+        return cube
+
+
+class PerformScalabilityGridToMesh(PerformScalabilityGridToGrid):
+    regridder = GridToMeshESMFRegridder
+    chunk_size = [grid_size / 2 * grid_size / 2, 10]
+
+    def tgt_cube(self):
+        from esmf_regrid.tests.unit.experimental.unstructured_scheme.test__mesh_to_MeshInfo import (
+            _gridlike_mesh,
+        )
+
+        tgt = Cube(np.ones([(self.grid_size / 10 + 1) * (self.grid_size / 10 + 1)]))
+        mesh = _gridlike_mesh(self.grid_size / 10 + 1, self.grid_size / 10 + 1)
+        mesh_coord_x, mesh_coord_y = mesh.to_MeshCoords("face")
+        tgt.add_aux_coord(mesh_coord_x, 0)
+        tgt.add_aux_coord(mesh_coord_y, 0)
+        return tgt

--- a/benchmarks/benchmarks/long/esmf_regridder.py
+++ b/benchmarks/benchmarks/long/esmf_regridder.py
@@ -17,7 +17,6 @@ from esmf_regrid.tests.unit.schemes.test__cube_to_GridInfo import _grid_cube
 
 
 class PrepareScalabilityGridToGrid:
-    # params = [50, 100, 200, 400, 600, 800, 1000, 2000]
     params = [50, 100, 200, 400, 600, 800]
     param_names = ["grid width"]
     height = 100
@@ -141,11 +140,7 @@ class PerformScalabilityGridToGrid:
 
 class PerformScalabilityMeshToGrid(PerformScalabilityGridToGrid):
     regridder = MeshToGridESMFRegridder
-    chunk_size = [
-        PerformScalabilityGridToGrid.grid_size
-        * PerformScalabilityGridToGrid.grid_size,
-        10,
-    ]
+    chunk_size = [PerformScalabilityGridToGrid.grid_size ^ 2, 10]
     file_name = "chunked_cube_1d.nc"
 
     def setup_cache(self):

--- a/benchmarks/benchmarks/long/esmf_regridder.py
+++ b/benchmarks/benchmarks/long/esmf_regridder.py
@@ -75,7 +75,7 @@ class PrepareScalabilityGridToMesh(PrepareScalabilityGridToGrid):
 class PerformScalabilityGridToGrid:
     params = [10, 100, 1000, 10000]
     grid_size = 500
-    chunk_size = [grid_size / 2, grid_size / 2, 10]
+    chunk_size = [self.grid_size / 2, self.grid_size / 2, 10]
     regridder = ESMFAreaWeightedRegridder
 
     def src_cube(self, height):
@@ -132,7 +132,7 @@ class PerformScalabilityGridToGrid:
 
 class PerformScalabilityMeshToGrid(PerformScalabilityGridToGrid):
     regridder = MeshToGridESMFRegridder
-    chunk_size = [grid_size / 2 * grid_size / 2, 10]
+    chunk_size = [self.grid_size / 2 * self.grid_size / 2, 10]
 
     def src_cube(self, height, chunk_size):
         data = da.ones(

--- a/benchmarks/benchmarks/long/esmf_regridder.py
+++ b/benchmarks/benchmarks/long/esmf_regridder.py
@@ -111,7 +111,7 @@ class PerformScalabilityGridToGrid:
         file = str(SYNTH_DATA_DIR.joinpath(self.file_name))
 
         src = self.src_cube(max(self.params))
-        # While iris is not able to save meshes, we add these after loading. 
+        # While iris is not able to save meshes, we add these after loading.
         # TODO: change this back after iris allows mesh saving.
         iris.save(src, file, chunksizes=self.chunk_size)
         loaded_src = iris.load_cube(file)

--- a/noxfile.py
+++ b/noxfile.py
@@ -339,10 +339,17 @@ def tests(session: nox.sessions.Session):
 @nox.session
 @nox.parametrize(
     ["ci_mode", "long_mode", "gh_pages"],
-    [(True, False, False), (False, False, False), (False, False, True), (False, True, False)],
+    [
+        (True, False, False),
+        (False, False, False),
+        (False, False, True),
+        (False, True, False),
+    ],
     ids=["ci compare", "full", "full then publish", "long snapshot"],
 )
-def benchmarks(session: nox.sessions.Session, ci_mode: bool, long_mode: bool, gh_pages: bool):
+def benchmarks(
+    session: nox.sessions.Session, ci_mode: bool, long_mode: bool, gh_pages: bool
+):
     """
     Perform esmf-regrid performance benchmarks (using Airspeed Velocity).
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -338,11 +338,11 @@ def tests(session: nox.sessions.Session):
 
 @nox.session
 @nox.parametrize(
-    ["ci_mode", "gh_pages"],
-    [(True, False), (False, False), (False, True)],
-    ids=["ci compare", "full", "full then publish"],
+    ["ci_mode", "long_mode", "gh_pages"],
+    [(True, False, False), (False, False, False), (False, False, True), (False, True, False)],
+    ids=["ci compare", "full", "full then publish", "long snapshot"],
 )
-def benchmarks(session: nox.sessions.Session, ci_mode: bool, gh_pages: bool):
+def benchmarks(session: nox.sessions.Session, ci_mode: bool, long_mode: bool, gh_pages: bool):
     """
     Perform esmf-regrid performance benchmarks (using Airspeed Velocity).
 
@@ -353,6 +353,8 @@ def benchmarks(session: nox.sessions.Session, ci_mode: bool, gh_pages: bool):
     ci_mode: bool
         Run a cut-down selection of benchmarks, comparing the current commit to
         the last commit for performance regressions.
+    long_mode: bool
+        Run the long running benchmarks at the current head of the repo.
     gh_pages: bool
         Run ``asv gh-pages --rewrite`` once finished.
 
@@ -383,6 +385,8 @@ def benchmarks(session: nox.sessions.Session, ci_mode: bool, gh_pages: bool):
             asv_exec("continuous", previous_commit, "HEAD", "--bench=ci")
         finally:
             asv_exec("compare", previous_commit, "HEAD")
+    elif long_mode:
+        asv_exec("run", "HEAD^!", "--bench=long")
     else:
         # f32f23a5 = first supporting commit for nox_asv_plugin.py .
         asv_exec("run", "f32f23a5..HEAD")

--- a/noxfile.py
+++ b/noxfile.py
@@ -386,7 +386,7 @@ def benchmarks(session: nox.sessions.Session, ci_mode: bool, long_mode: bool, gh
         finally:
             asv_exec("compare", previous_commit, "HEAD")
     elif long_mode:
-        asv_exec("run", "HEAD^!", "--bench=long", "-e")
+        asv_exec("run", "HEAD^!", "--bench=long")
     else:
         # f32f23a5 = first supporting commit for nox_asv_plugin.py .
         asv_exec("run", "f32f23a5..HEAD")

--- a/noxfile.py
+++ b/noxfile.py
@@ -386,7 +386,7 @@ def benchmarks(session: nox.sessions.Session, ci_mode: bool, long_mode: bool, gh
         finally:
             asv_exec("compare", previous_commit, "HEAD")
     elif long_mode:
-        asv_exec("run", "HEAD^!", "--bench=long")
+        asv_exec("run", "HEAD^!", "--bench=long", "-e")
     else:
         # f32f23a5 = first supporting commit for nox_asv_plugin.py .
         asv_exec("run", "f32f23a5..HEAD")


### PR DESCRIPTION
Add performance tests for preparing a regridder to the CI performance tests and add long running performance tests (with the ability to run them separately via nox) which test the scalability of preparing and performing with real and lazy data for all the regridders.