### PR TITLE
Prep 0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
  
-## [Unreleased]
+## [0.4] - 2022-02-24
 
 This release added the ability to regrid data stored on a UGRID mesh.
 

--- a/esmf_regrid/__init__.py
+++ b/esmf_regrid/__init__.py
@@ -1,4 +1,4 @@
 from .schemes import *
 
 
-__version__ = "0.4.dev0"
+__version__ = "0.4.0"


### PR DESCRIPTION
Updates to the version string and `CHANGELOG.md` to mark the release of `v0.4`.