### PR TITLE
Increase standard benchmark regression tolerance

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -400,9 +400,9 @@ def benchmarks(
         #  Else: compare to previous commit.
         previous_commit = os.environ.get("CIRRUS_BASE_SHA", "HEAD^1")
         try:
-            asv_exec("continuous", previous_commit, "HEAD", "--bench=ci")
+            asv_exec("continuous", previous_commit, "HEAD", "--bench=ci", "--factor=2")
         finally:
-            asv_exec("compare", previous_commit, "HEAD")
+            asv_exec("compare", previous_commit, "HEAD", "--factor=2")
     elif long_mode:
         asv_exec("run", "HEAD^!", "--bench=long")
     else:


### PR DESCRIPTION
Benchmarks are currently over-sensitive and regularly flag false positive regressions.