### PR TITLE
Align pinning of Python version with Iris

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -28,7 +28,7 @@ version = attr: esmf_regrid.__version__
 [options]
 packages = find:
 python_requires =
-    >=3.8,<3.9
+    >=3.8
 setup_requires =
     setuptools>=40.8.0
 zip_safe = False


### PR DESCRIPTION
This aligns the pinning of the Python version with Iris, i.e. not blocking the installation on higher Python versions without claiming support for them.

