### PR TITLE
Make weights array handling more robust

### DIFF
--- a/esmf_regrid/esmf_regridder.py
+++ b/esmf_regrid/esmf_regridder.py
@@ -161,7 +161,7 @@ class Regridder:
         extra_shape = array_shape[: -self.src.dims]
         extra_size = max(1, np.prod(extra_shape))
         src_inverted_mask = self.src._array_to_matrix(~ma.getmaskarray(src_array))
-        weight_sums = self.weight_matrix * src_inverted_mask
+        weight_sums = self.weight_matrix @ src_inverted_mask
         # Set the minimum mdtol to be slightly higher than 0 to account for rounding
         # errors.
         mdtol = max(mdtol, 1e-8)
@@ -177,7 +177,7 @@ class Regridder:
         normalisations = ma.array(normalisations, mask=np.logical_not(tgt_mask))
 
         flat_src = self.src._array_to_matrix(ma.filled(src_array, 0.0))
-        flat_tgt = self.weight_matrix * flat_src
+        flat_tgt = self.weight_matrix @ flat_src
         flat_tgt = flat_tgt * normalisations
         tgt_array = self.tgt._matrix_to_array(flat_tgt, extra_shape)
         return tgt_array

--- a/esmf_regrid/experimental/io.py
+++ b/esmf_regrid/experimental/io.py
@@ -89,7 +89,7 @@ def save_regridder(rg, filename):
     method = rg.method
 
     weight_matrix = rg.regridder.weight_matrix
-    reformatted_weight_matrix = weight_matrix.tocoo()
+    reformatted_weight_matrix = scipy.sparse.coo_matrix(weight_matrix)
     weight_data = reformatted_weight_matrix.data
     weight_rows = reformatted_weight_matrix.row
     weight_cols = reformatted_weight_matrix.col


### PR DESCRIPTION
With scipy.sparse now offering arrays as well as matrices, the code ought to be improved so that it can work with either matrices or arrays representing the weights, especially since precomputed weights could potentially be given in either form. This also clarifies in the code where matrix multiplication is happening rather than array multiplication.