### PR TITLE
Unify unstructured and rectilinear schemes (curvilinear support)

### DIFF
--- a/esmf_regrid/experimental/unstructured_scheme.py
+++ b/esmf_regrid/experimental/unstructured_scheme.py
@@ -9,7 +9,7 @@ import numpy as np
 
 from esmf_regrid.esmf_regridder import GridInfo, RefinedGridInfo, Regridder
 from esmf_regrid.experimental.unstructured_regrid import MeshInfo
-from esmf_regrid.schemes import _cube_to_GridInfo, _create_cube
+from esmf_regrid.schemes import _create_cube, _cube_to_GridInfo
 
 
 def _map_complete_blocks(src, func, dims, out_sizes):

--- a/esmf_regrid/experimental/unstructured_scheme.py
+++ b/esmf_regrid/experimental/unstructured_scheme.py
@@ -3,11 +3,10 @@
 import copy
 import functools
 
-import iris
 from iris.analysis._interpolation import get_xy_dim_coords
 import numpy as np
 
-from esmf_regrid.esmf_regridder import GridInfo, RefinedGridInfo, Regridder
+from esmf_regrid.esmf_regridder import Regridder
 from esmf_regrid.experimental.unstructured_regrid import MeshInfo
 from esmf_regrid.schemes import _create_cube, _cube_to_GridInfo
 

--- a/esmf_regrid/schemes.py
+++ b/esmf_regrid/schemes.py
@@ -6,6 +6,7 @@ import functools
 
 from cf_units import Unit
 import iris
+from iris.coords import DimCoord
 from iris._lazy_data import map_complete_blocks
 import numpy as np
 

--- a/esmf_regrid/schemes.py
+++ b/esmf_regrid/schemes.py
@@ -165,8 +165,7 @@ def _create_cube(data, src_cube, src_dims, tgt_coords, num_tgt_dims):
                 if src_dim in dims:
                     continue
             offset = num_tgt_dims - len(src_dims)
-            if len(src_dims) == 1:
-                dims = [dim if dim < max(src_dims) else dim + offset for dim in dims]
+            dims = [dim if dim < max(src_dims) else dim + offset for dim in dims]
             result_coord = coord.copy()
             # Add result_coord to the owner of add_method.
             add_method(result_coord, dims)

--- a/esmf_regrid/schemes.py
+++ b/esmf_regrid/schemes.py
@@ -58,7 +58,6 @@ def _cube_to_GridInfo(cube, center=False, resolution=None):
             crs=crs,
             circular=circular,
             center=center,
-            resolution=resolution,
         )
     else:
         grid_info = RefinedGridInfo(

--- a/esmf_regrid/schemes.py
+++ b/esmf_regrid/schemes.py
@@ -146,7 +146,7 @@ def _create_cube(data, src_cube, src_dims, tgt_coords, num_tgt_dims):
         )
     if num_tgt_dims == 1:
         grid_dim_x = grid_dim_y = min(src_dims)
-    for tgt_coord, dim in tgt_coords, (grid_dim_x, grid_dim_y):
+    for tgt_coord, dim in zip(tgt_coords, (grid_dim_x, grid_dim_y)):
         if len(tgt_coord.shape) == 1:
             if isinstance(tgt_coord, DimCoord):
                 new_cube.add_dim_coord(tgt_coord, dim)

--- a/esmf_regrid/schemes.py
+++ b/esmf_regrid/schemes.py
@@ -5,12 +5,12 @@ import copy
 import functools
 
 from cf_units import Unit
-import iris
-from iris.coords import DimCoord
 from iris._lazy_data import map_complete_blocks
+import iris.coords
+import iris.cube
 import numpy as np
 
-from esmf_regrid.esmf_regridder import GridInfo, Regridder
+from esmf_regrid.esmf_regridder import GridInfo, RefinedGridInfo, Regridder
 
 __all__ = [
     "ESMFAreaWeighted",
@@ -149,7 +149,7 @@ def _create_cube(data, src_cube, src_dims, tgt_coords, num_tgt_dims):
         grid_dim_x = grid_dim_y = min(src_dims)
     for tgt_coord, dim in zip(tgt_coords, (grid_dim_x, grid_dim_y)):
         if len(tgt_coord.shape) == 1:
-            if isinstance(tgt_coord, DimCoord):
+            if isinstance(tgt_coord, iris.coords.DimCoord):
                 new_cube.add_dim_coord(tgt_coord, dim)
             else:
                 new_cube.add_aux_coord(tgt_coord, dim)
@@ -161,9 +161,8 @@ def _create_cube(data, src_cube, src_dims, tgt_coords, num_tgt_dims):
     def copy_coords(src_coords, add_method):
         for coord in src_coords:
             dims = src_cube.coord_dims(coord)
-            for src_dim in src_dims:
-                if src_dim in dims:
-                    continue
+            if set(src_dims).intersection(set(dims)):
+                continue
             offset = num_tgt_dims - len(src_dims)
             dims = [dim if dim < max(src_dims) else dim + offset for dim in dims]
             result_coord = coord.copy()

--- a/esmf_regrid/tests/unit/experimental/unstructured_scheme/test_GridToMeshESMFRegridder.py
+++ b/esmf_regrid/tests/unit/experimental/unstructured_scheme/test_GridToMeshESMFRegridder.py
@@ -10,8 +10,9 @@ import pytest
 from esmf_regrid.experimental.unstructured_scheme import (
     GridToMeshESMFRegridder,
 )
-from esmf_regrid.tests.unit.experimental.unstructured_scheme.test__cube_to_GridInfo import (
+from esmf_regrid.tests.unit.schemes.test__cube_to_GridInfo import (
     _grid_cube,
+    _curvilinear_cube,
 )
 from esmf_regrid.tests.unit.experimental.unstructured_scheme.test__mesh_to_MeshInfo import (
     _gridlike_mesh,
@@ -372,3 +373,51 @@ def test_resolution():
     result = GridToMeshESMFRegridder(grid, tgt, resolution=resolution)
     assert result.resolution == resolution
     assert result.regridder.src.resolution == resolution
+
+
+def test_curvilinear():
+    """
+    Test for :func:`esmf_regrid.experimental.unstructured_scheme.regrid_rectilinear_to_unstructured`.
+
+    Tests with curvilinear target cube.
+    """
+    tgt = _flat_mesh_cube()
+    mesh = tgt.mesh
+    mesh_length = mesh.connectivity(contains_face=True).shape[0]
+    n_lons = 6
+    n_lats = 5
+    lon_bounds = (-180, 180)
+    lat_bounds = (-90, 90)
+    grid = _curvilinear_cube(n_lons, n_lats, lon_bounds, lat_bounds)
+
+    h = 2
+    t = 3
+    height = DimCoord(np.arange(h), standard_name="height")
+    time = DimCoord(np.arange(t), standard_name="time")
+
+    src_data = np.empty([t, n_lats, n_lons, h])
+    src_data[:] = np.arange(t * h).reshape([t, h])[:, np.newaxis, np.newaxis, :]
+    cube = Cube(src_data)
+    cube.add_aux_coord(grid.coord("latitude"), [1, 2])
+    cube.add_aux_coord(grid.coord("longitude"), [1, 2])
+    cube.add_dim_coord(time, 0)
+    cube.add_dim_coord(height, 3)
+
+    regridder = GridToMeshESMFRegridder(grid, tgt)
+    result = regridder(cube)
+
+    # Lenient check for data.
+    expected_data = np.empty([t, mesh_length, h])
+    expected_data[:] = np.arange(t * h).reshape(t, h)[:, np.newaxis, :]
+    assert np.allclose(expected_data, result.data)
+
+    mesh_coord_x, mesh_coord_y = mesh.to_MeshCoords("face")
+    expected_cube = Cube(expected_data)
+    expected_cube.add_dim_coord(time, 0)
+    expected_cube.add_aux_coord(mesh_coord_x, 1)
+    expected_cube.add_aux_coord(mesh_coord_y, 1)
+    expected_cube.add_dim_coord(height, 2)
+
+    # Check metadata and scalar coords.
+    result.data = expected_data
+    assert expected_cube == result

--- a/esmf_regrid/tests/unit/experimental/unstructured_scheme/test_MeshToGridESMFRegridder.py
+++ b/esmf_regrid/tests/unit/experimental/unstructured_scheme/test_MeshToGridESMFRegridder.py
@@ -9,8 +9,9 @@ import pytest
 from esmf_regrid.experimental.unstructured_scheme import (
     MeshToGridESMFRegridder,
 )
-from esmf_regrid.tests.unit.experimental.unstructured_scheme.test__cube_to_GridInfo import (
+from esmf_regrid.tests.unit.schemes.test__cube_to_GridInfo import (
     _grid_cube,
+    _curvilinear_cube,
 )
 from esmf_regrid.tests.unit.experimental.unstructured_scheme.test__mesh_to_MeshInfo import (
     _gridlike_mesh,
@@ -346,3 +347,53 @@ def test_resolution():
     lat_band_rg = MeshToGridESMFRegridder(mesh_cube, lat_bands, resolution=resolution)
     assert lat_band_rg.resolution == resolution
     assert lat_band_rg.regridder.tgt.resolution == resolution
+
+
+def test_curvilinear():
+    """
+    Test for :func:`esmf_regrid.experimental.unstructured_scheme.MeshToGridESMFRegridder`.
+
+    Tests with curvilinear source cube.
+    """
+    mesh = _full_mesh()
+    mesh_length = mesh.connectivity(contains_face=True).shape[0]
+
+    h = 2
+    t = 3
+    height = DimCoord(np.arange(h), standard_name="height")
+    time = DimCoord(np.arange(t), standard_name="time")
+
+    src_data = np.empty([t, mesh_length, h])
+    src_data[:] = np.arange(t * h).reshape([t, h])[:, np.newaxis, :]
+    mesh_cube = Cube(src_data)
+    mesh_coord_x, mesh_coord_y = mesh.to_MeshCoords("face")
+    mesh_cube.add_aux_coord(mesh_coord_x, 1)
+    mesh_cube.add_aux_coord(mesh_coord_y, 1)
+    mesh_cube.add_dim_coord(time, 0)
+    mesh_cube.add_dim_coord(height, 2)
+
+    n_lons = 6
+    n_lats = 5
+    lon_bounds = (-180, 180)
+    lat_bounds = (-90, 90)
+    tgt = _curvilinear_cube(n_lons, n_lats, lon_bounds, lat_bounds)
+
+    src_cube = mesh_cube.copy()
+    src_cube.transpose([1, 0, 2])
+    regridder = MeshToGridESMFRegridder(src_cube, tgt)
+    result = regridder(mesh_cube)
+
+    # Lenient check for data.
+    expected_data = np.empty([t, n_lats, n_lons, h])
+    expected_data[:] = np.arange(t * h).reshape(t, h)[:, np.newaxis, np.newaxis, :]
+    assert np.allclose(expected_data, result.data)
+
+    expected_cube = Cube(expected_data)
+    expected_cube.add_dim_coord(time, 0)
+    expected_cube.add_aux_coord(tgt.coord("latitude"), [1, 2])
+    expected_cube.add_aux_coord(tgt.coord("longitude"), [1, 2])
+    expected_cube.add_dim_coord(height, 3)
+
+    # Check metadata and scalar coords.
+    result.data = expected_data
+    assert expected_cube == result

--- a/esmf_regrid/tests/unit/experimental/unstructured_scheme/test__create_cube.py
+++ b/esmf_regrid/tests/unit/experimental/unstructured_scheme/test__create_cube.py
@@ -27,7 +27,7 @@ def test_create_cube_2D():
     grid_x = DimCoord(np.arange(3), standard_name="longitude")
     grid_y = DimCoord(np.arange(2), standard_name="latitude")
 
-    cube = _create_cube(data, src_cube, mesh_dim, grid_x, grid_y)
+    cube = _create_cube(data, src_cube, (mesh_dim,), (grid_x, grid_y), 2)
     src_metadata = src_cube.metadata
 
     expected_cube = Cube(data)
@@ -66,7 +66,7 @@ def test_create_cube_4D():
     grid_x = iris.coords.DimCoord(np.arange(3), standard_name="longitude")
     grid_y = iris.coords.DimCoord(np.arange(2), standard_name="latitude")
 
-    cube = _create_cube(data, src_cube, mesh_dim, grid_x, grid_y)
+    cube = _create_cube(data, src_cube, (mesh_dim,), (grid_x, grid_y), 2)
     src_metadata = src_cube.metadata
 
     expected_cube = iris.cube.Cube(data)


### PR DESCRIPTION
Generalises the helper functions (`_cube_to_GridInfo` and `_create_cube`) so that one of each type of function can be used for all regridding schemes. This reduces code copying and begins to unify the behaviour of the regridders.

This adds curvilinear support to the unstructured regridders.