### PR TITLE
Allow regridding for projections in non-degree type units

### DIFF
--- a/esmf_regrid/schemes.py
+++ b/esmf_regrid/schemes.py
@@ -196,8 +196,8 @@ def _cube_to_GridInfo(cube, center=False, resolution=None, mask=None):
     if crs is None:
         lon_bound_array = lon.units.convert(lon_bound_array, Unit("degrees"))
         lat_bound_array = lat.units.convert(lat_bound_array, Unit("degrees"))
-        lon_points = lon.units.convert(lon.points, Unit("degrees"))
-        lat_points = lon.units.convert(lat.points, Unit("degrees"))
+        lon_points = lon.units.convert(lon_points, Unit("degrees"))
+        lat_points = lon.units.convert(lat_points, Unit("degrees"))
     if resolution is None:
         grid_info = GridInfo(
             lon_points,

--- a/esmf_regrid/schemes.py
+++ b/esmf_regrid/schemes.py
@@ -191,6 +191,8 @@ def _cube_to_GridInfo(cube, center=False, resolution=None, mask=None):
             lat_bound_array = _contiguous_masked(lat.bounds, mask)
         # 2D coords must be AuxCoords, which do not have a circular attribute.
         circular = False
+    lon_points = lon.points
+    lat_points = lat.points
     if crs is None:
         lon_bound_array = lon.units.convert(lon_bound_array, Unit("degrees"))
         lat_bound_array = lat.units.convert(lat_bound_array, Unit("degrees"))

--- a/esmf_regrid/schemes.py
+++ b/esmf_regrid/schemes.py
@@ -191,10 +191,11 @@ def _cube_to_GridInfo(cube, center=False, resolution=None, mask=None):
             lat_bound_array = _contiguous_masked(lat.bounds, mask)
         # 2D coords must be AuxCoords, which do not have a circular attribute.
         circular = False
-    lon_bound_array = lon.units.convert(lon_bound_array, Unit("degrees"))
-    lat_bound_array = lat.units.convert(lat_bound_array, Unit("degrees"))
-    lon_points = lon.units.convert(lon.points, Unit("degrees"))
-    lat_points = lon.units.convert(lat.points, Unit("degrees"))
+    if crs is None:
+        lon_bound_array = lon.units.convert(lon_bound_array, Unit("degrees"))
+        lat_bound_array = lat.units.convert(lat_bound_array, Unit("degrees"))
+        lon_points = lon.units.convert(lon.points, Unit("degrees"))
+        lat_points = lon.units.convert(lat.points, Unit("degrees"))
     if resolution is None:
         grid_info = GridInfo(
             lon_points,

--- a/esmf_regrid/tests/unit/schemes/__init__.py
+++ b/esmf_regrid/tests/unit/schemes/__init__.py
@@ -1,6 +1,6 @@
 """Unit tests for `esmf_regrid.schemes`."""
 
-from iris.coord_systems import TransverseMercator, GeogCS
+from iris.coord_systems import GeogCS, TransverseMercator
 import numpy as np
 from numpy import ma
 import pytest
@@ -170,7 +170,7 @@ def _test_mask_from_regridder(scheme, mask_keyword):
 
 
 def _test_non_degree_crs(scheme, expected_sum, expected_unmasked):
-    """Test regridding scheme is compatible with coordinates with non-degree units"""
+    """Test regridding scheme is compatible with coordinates with non-degree units."""
     coord_system = TransverseMercator(
         49,
         -2,
@@ -208,7 +208,7 @@ def _test_non_degree_crs(scheme, expected_sum, expected_unmasked):
     result = tm_cube.regrid(cube_tgt, scheme())
 
     # Check that the data is as expected.
-    assert result.data.sum() == expected_sum
+    assert np.isclose(result.data.sum(), expected_sum)
 
     # Check that the number of masked points is as expected.
     assert (1 - result.data.mask).sum() == expected_unmasked

--- a/esmf_regrid/tests/unit/schemes/__init__.py
+++ b/esmf_regrid/tests/unit/schemes/__init__.py
@@ -1,5 +1,6 @@
 """Unit tests for `esmf_regrid.schemes`."""
 
+from iris.coord_systems import TransverseMercator, GeogCS
 import numpy as np
 from numpy import ma
 import pytest
@@ -166,3 +167,48 @@ def _test_mask_from_regridder(scheme, mask_keyword):
     np.testing.assert_allclose(
         getattr(rg_from_different, regridder_attr), mask_different
     )
+
+
+def _test_non_degree_crs(scheme, expected_sum, expected_unmasked):
+    """Test regridding scheme is compatible with coordinates with non-degree units"""
+    coord_system = TransverseMercator(
+        49,
+        -2,
+        false_easting=400000,
+        false_northing=-100000,
+        scale_factor_at_central_meridian=0.9996012717,
+        ellipsoid=GeogCS(semi_major_axis=6377563.396, semi_minor_axis=6356256.91),
+    )
+
+    n_lons_src = 2
+    n_lats_src = 3
+    lon_bounds = (-197500, -192500)
+    lat_bounds = (1247500, 1237500)
+    tm_cube = _grid_cube(
+        n_lons_src,
+        n_lats_src,
+        lon_bounds,
+        lat_bounds,
+        circular=False,
+        coord_system=coord_system,
+        standard_names=["projection_x_coordinate", "projection_y_coordinate"],
+        units="m",
+    )
+    data = np.arange(n_lats_src * n_lons_src).reshape([n_lats_src, n_lons_src])
+    tm_cube.data = data
+
+    n_lons_tgt = 12
+    n_lats_tgt = 14
+    lon_bounds_tgt = (-13, -12.8)
+    lat_bounds_tgt = (60.5, 60.7)
+    cube_tgt = _grid_cube(
+        n_lons_tgt, n_lats_tgt, lon_bounds_tgt, lat_bounds_tgt, circular=True
+    )
+
+    result = tm_cube.regrid(cube_tgt, scheme())
+
+    # Check that the data is as expected.
+    assert result.data.sum() == expected_sum
+
+    # Check that the number of masked points is as expected.
+    assert (1 - result.data.mask).sum() == expected_unmasked

--- a/esmf_regrid/tests/unit/schemes/test_ESMFAreaWeighted.py
+++ b/esmf_regrid/tests/unit/schemes/test_ESMFAreaWeighted.py
@@ -67,6 +67,4 @@ def test_invalid_tgt_location():
 
 def test_non_degree_crs():
     """Test for coordinates with non-degree units."""
-    expected_sum = 50.86147272655136
-    expected_unmasked = 21
-    _test_non_degree_crs(ESMFAreaWeighted, expected_sum, expected_unmasked)
+    _test_non_degree_crs(ESMFAreaWeighted)

--- a/esmf_regrid/tests/unit/schemes/test_ESMFAreaWeighted.py
+++ b/esmf_regrid/tests/unit/schemes/test_ESMFAreaWeighted.py
@@ -66,7 +66,7 @@ def test_invalid_tgt_location():
 
 
 def test_non_degree_crs():
-    """Test for coordinates with non-degree units"""
+    """Test for coordinates with non-degree units."""
     expected_sum = 50.86147272655136
     expected_unmasked = 21
     _test_non_degree_crs(ESMFAreaWeighted, expected_sum, expected_unmasked)

--- a/esmf_regrid/tests/unit/schemes/test_ESMFAreaWeighted.py
+++ b/esmf_regrid/tests/unit/schemes/test_ESMFAreaWeighted.py
@@ -8,6 +8,7 @@ from esmf_regrid.tests.unit.schemes.__init__ import (
     _test_invalid_mdtol,
     _test_mask_from_init,
     _test_mask_from_regridder,
+    _test_non_degree_crs,
 )
 
 
@@ -62,3 +63,10 @@ def test_invalid_tgt_location():
     match = "For area weighted regridding, target location must be 'face'."
     with pytest.raises(ValueError, match=match):
         _ = ESMFAreaWeighted(tgt_location="node")
+
+
+def test_non_degree_crs():
+    """Test for coordinates with non-degree units"""
+    expected_sum = 50.86147272655136
+    expected_unmasked = 21
+    _test_non_degree_crs(ESMFAreaWeighted, expected_sum, expected_unmasked)

--- a/esmf_regrid/tests/unit/schemes/test_ESMFBilinear.py
+++ b/esmf_regrid/tests/unit/schemes/test_ESMFBilinear.py
@@ -8,6 +8,7 @@ from esmf_regrid.tests.unit.schemes.__init__ import (
     _test_invalid_mdtol,
     _test_mask_from_init,
     _test_mask_from_regridder,
+    _test_non_degree_crs,
 )
 
 
@@ -51,3 +52,10 @@ def test_mask_from_regridder(mask_keyword):
     Checks that use_src_mask and use_tgt_mask are passed down correctly.
     """
     _test_mask_from_regridder(ESMFBilinear, mask_keyword)
+
+
+def test_non_degree_crs():
+    """Test for coordinates with non-degree units"""
+    expected_sum = 35.90837983047451
+    expected_unmasked = 13
+    _test_non_degree_crs(ESMFBilinear, expected_sum, expected_unmasked)

--- a/esmf_regrid/tests/unit/schemes/test_ESMFBilinear.py
+++ b/esmf_regrid/tests/unit/schemes/test_ESMFBilinear.py
@@ -56,6 +56,4 @@ def test_mask_from_regridder(mask_keyword):
 
 def test_non_degree_crs():
     """Test for coordinates with non-degree units."""
-    expected_sum = 35.90837983047451
-    expected_unmasked = 13
-    _test_non_degree_crs(ESMFBilinear, expected_sum, expected_unmasked)
+    _test_non_degree_crs(ESMFBilinear)

--- a/esmf_regrid/tests/unit/schemes/test_ESMFBilinear.py
+++ b/esmf_regrid/tests/unit/schemes/test_ESMFBilinear.py
@@ -55,7 +55,7 @@ def test_mask_from_regridder(mask_keyword):
 
 
 def test_non_degree_crs():
-    """Test for coordinates with non-degree units"""
+    """Test for coordinates with non-degree units."""
     expected_sum = 35.90837983047451
     expected_unmasked = 13
     _test_non_degree_crs(ESMFBilinear, expected_sum, expected_unmasked)

--- a/esmf_regrid/tests/unit/schemes/test_ESMFNearest.py
+++ b/esmf_regrid/tests/unit/schemes/test_ESMFNearest.py
@@ -8,6 +8,7 @@ from esmf_regrid.schemes import ESMFNearest
 from esmf_regrid.tests.unit.schemes.__init__ import (
     _test_mask_from_init,
     _test_mask_from_regridder,
+    _test_non_degree_crs,
 )
 from esmf_regrid.tests.unit.schemes.test__cube_to_GridInfo import _grid_cube
 from esmf_regrid.tests.unit.schemes.test__mesh_to_MeshInfo import (
@@ -94,3 +95,10 @@ def test_mask_from_regridder(mask_keyword):
     Checks that use_src_mask and use_tgt_mask are passed down correctly.
     """
     _test_mask_from_regridder(ESMFNearest, mask_keyword)
+
+
+def test_non_degree_crs():
+    """Test for coordinates with non-degree units"""
+    expected_sum = 490
+    expected_unmasked = 168
+    _test_non_degree_crs(ESMFNearest, expected_sum, expected_unmasked)

--- a/esmf_regrid/tests/unit/schemes/test_ESMFNearest.py
+++ b/esmf_regrid/tests/unit/schemes/test_ESMFNearest.py
@@ -98,7 +98,7 @@ def test_mask_from_regridder(mask_keyword):
 
 
 def test_non_degree_crs():
-    """Test for coordinates with non-degree units"""
+    """Test for coordinates with non-degree units."""
     expected_sum = 490
     expected_unmasked = 168
     _test_non_degree_crs(ESMFNearest, expected_sum, expected_unmasked)

--- a/esmf_regrid/tests/unit/schemes/test_ESMFNearest.py
+++ b/esmf_regrid/tests/unit/schemes/test_ESMFNearest.py
@@ -99,6 +99,4 @@ def test_mask_from_regridder(mask_keyword):
 
 def test_non_degree_crs():
     """Test for coordinates with non-degree units."""
-    expected_sum = 490
-    expected_unmasked = 168
-    _test_non_degree_crs(ESMFNearest, expected_sum, expected_unmasked)
+    _test_non_degree_crs(ESMFNearest)

--- a/esmf_regrid/tests/unit/schemes/test__cube_to_GridInfo.py
+++ b/esmf_regrid/tests/unit/schemes/test__cube_to_GridInfo.py
@@ -67,12 +67,14 @@ def _grid_cube(
     lat_outer_bounds,
     circular=False,
     coord_system=None,
+    standard_names=["longitude", "latitude"],
+    units="degrees",
 ):
     lon_points, lon_bounds = _generate_points_and_bounds(n_lons, lon_outer_bounds)
     lon = DimCoord(
         lon_points,
-        "longitude",
-        units="degrees",
+        standard_names[0],
+        units=units,
         bounds=lon_bounds,
         circular=circular,
         coord_system=coord_system,
@@ -80,8 +82,8 @@ def _grid_cube(
     lat_points, lat_bounds = _generate_points_and_bounds(n_lats, lat_outer_bounds)
     lat = DimCoord(
         lat_points,
-        "latitude",
-        units="degrees",
+        standard_names[1],
+        units=units,
         bounds=lat_bounds,
         coord_system=coord_system,
     )


### PR DESCRIPTION
Addresses #222 

Some projections, like OSGB, have units which cannot be converted to degrees (i.e. meters) and cause regridding to fail. This PR assumes that where a coordinate system exists, units ought to already be compatible with it.