### PR TITLE
Enable benchmarking to run on `main`

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -166,7 +166,8 @@ benchmark_task:
       - echo "${NOX_CACHE_BUILD}"
       - if [ -n "${IRIS_SOURCE}" ]; then echo "${IRIS_SOURCE}"; fi
   benchmarks_script:
+    - if [ -z "$CIRRUS_BASE_SHA" ]; then export COMPARE="HEAD~" else export COMPARE="${CIRRUS_BASE_SHA}" fi
     - export CONDA_OVERRIDE_LINUX="$(uname -r | cut -d'+' -f1)"
     - nox --session=tests --install-only
     - export DATA_GEN_PYTHON=$(realpath $(find .nox -path "*tests*bin/python"))
-    - nox --no-reuse-existing-virtualenvs --session="benchmarks(branch)" -- "${CIRRUS_BASE_SHA}"
+    - nox --no-reuse-existing-virtualenvs --session="benchmarks(branch)" -- "${COMPARE}"

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -166,7 +166,7 @@ benchmark_task:
       - echo "${NOX_CACHE_BUILD}"
       - if [ -n "${IRIS_SOURCE}" ]; then echo "${IRIS_SOURCE}"; fi
   benchmarks_script:
-    - if [ -z "$CIRRUS_BASE_SHA" ]; then export COMPARE="HEAD~" else export COMPARE="${CIRRUS_BASE_SHA}" fi
+    - if [ -z "$CIRRUS_BASE_SHA" ]; then export COMPARE="HEAD~"; else export COMPARE="${CIRRUS_BASE_SHA}"; fi;
     - export CONDA_OVERRIDE_LINUX="$(uname -r | cut -d'+' -f1)"
     - nox --session=tests --install-only
     - export DATA_GEN_PYTHON=$(realpath $(find .nox -path "*tests*bin/python"))


### PR DESCRIPTION
Fixes an oversight where Cirrus' benchmarking script depended entirely on `$CIRRUS_BASE_SHA`, which only exists on pull requests.