### PR TITLE
Remove flake8 and black Nox sessions.

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -16,7 +16,6 @@ container:
 
 env:
   # Skip specific tasks by name. Set to a non-empty string to skip.
-  SKIP_LINT_TASK: ""
   SKIP_TEST_TASK: ""
   SKIP_BENCHMARK_TASK: ""
   # Maximum cache period (in weeks) before forcing a new cache upload.
@@ -79,27 +78,6 @@ LINUX_CONDA_TEMPLATE: &LINUX_CONDA_TEMPLATE
       - conda config --add channels conda-forge
       - conda update --quiet --name base conda
       - conda install --quiet --name base ${CONDA_CACHE_PACKAGES}
-
-
-#
-# Linting
-#
-lint_task:
-  only_if: ${SKIP_LINT_TASK} == ""
-  auto_cancellation: true
-  name: "${CIRRUS_OS}: flake8 and black"
-  pip_cache:
-    folder: ~/.cache/pip
-    fingerprint_script:
-      - echo "${CIRRUS_TASK_NAME} py${PYTHON_VERSION}"
-      - echo "${PIP_CACHE_PACKAGES}"
-      - echo "$(date +%Y).$(expr $(date +%U) / ${CACHE_PERIOD}):${PIP_CACHE_BUILD}"
-  lint_script:
-    - pip list
-    - python -m pip install --retries 3 --upgrade ${PIP_CACHE_PACKAGES}
-    - pip list
-    - nox --session flake8
-    - nox --session black
 
 
 #

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,3 +29,7 @@ repos:
         # Run flake8.
     -   id: flake8
         args: [--config=./.flake8]
+        additional_dependencies: [
+            'flake8-docstrings==1.6.0',
+            'flake8-import-order==0.18.2',
+        ]

--- a/benchmarks/asv_delegated_conda.py
+++ b/benchmarks/asv_delegated_conda.py
@@ -1,8 +1,4 @@
-"""
-ASV plug-in providing an alternative :class:`asv.plugins.conda.Conda`
-subclass that manages the Conda environment via custom user scripts.
-
-"""
+"""ASV plug-in - managing Conda environment via custom user scripts."""
 
 from os import environ
 from os.path import getmtime
@@ -41,6 +37,8 @@ class CondaDelegated(Conda):
         tagged_env_vars: dict,
     ) -> None:
         """
+        Create the instance.
+
         Parameters
         ----------
         conf : Config instance

--- a/benchmarks/benchmarks/__init__.py
+++ b/benchmarks/benchmarks/__init__.py
@@ -1,4 +1,4 @@
-"""Benchmark tests for iris-esmf-regrid"""
+"""Benchmark tests for iris-esmf-regrid."""
 
 
 from os import environ
@@ -6,7 +6,7 @@ from os import environ
 
 def disable_repeat_between_setup(benchmark_object):
     """
-    Decorator for benchmarks where object persistence would be inappropriate.
+    Decorate benchmarks where object persistence would be inappropriate.
 
     E.g:
         * Data is realised during testing.
@@ -32,7 +32,7 @@ def disable_repeat_between_setup(benchmark_object):
 
 def skip_benchmark(benchmark_object):
     """
-    Decorator for benchmarks skipping benchmarks.
+    Decorate benchmarks to be skipped.
 
     Simply doesn't return the object.
 
@@ -49,7 +49,7 @@ def skip_benchmark(benchmark_object):
 
 def on_demand_benchmark(benchmark_object):
     """
-    Decorator. Disables these benchmark(s) unless ON_DEMAND_BENCHARKS env var is set.
+    Decorate benchmark(s) that are disabled unless ON_DEMAND_BENCHARKS env var is set.
 
     For benchmarks that, for whatever reason, should not be run by default.
     E.g:

--- a/benchmarks/benchmarks/generate_data.py
+++ b/benchmarks/benchmarks/generate_data.py
@@ -12,10 +12,10 @@ benchmark sequence runs over two different Python versions.
 
 """
 from inspect import getsource
-from subprocess import CalledProcessError, check_output, run
 from os import environ
 from pathlib import Path
 import re
+from subprocess import CalledProcessError, check_output, run
 from textwrap import dedent
 from warnings import warn
 
@@ -104,7 +104,7 @@ def _grid_cube(
     circular=False,
     alt_coord_system=False,
 ):
-    """Wrapper for calling _grid_cube via :func:`run_function_elsewhere`."""
+    """Call _grid_cube via :func:`run_function_elsewhere`."""
 
     def external(*args, **kwargs):
         """
@@ -162,7 +162,7 @@ def _grid_cube(
 
 
 def _gridlike_mesh_cube(n_lons, n_lats):
-    """Wrapper for calling _gridlike_mesh via :func:`run_function_elsewhere`."""
+    """Call _gridlike_mesh via :func:`run_function_elsewhere`."""
 
     def external(*args, **kwargs):
         """

--- a/noxfile.py
+++ b/noxfile.py
@@ -275,44 +275,6 @@ def update_lockfiles(session: nox.sessions.Session):
         print(f"Conda lock file created: {lockfile_path}")
 
 
-@nox.session
-def flake8(session: nox.sessions.Session):
-    """
-    Perform flake8 linting of the code-base.
-
-    Parameters
-    ----------
-    session: object
-        A `nox.sessions.Session` object.
-
-    """
-    # Pip install the session requirements.
-    session.install("flake8", "flake8-docstrings", "flake8-import-order")
-    # Execute the flake8 linter on the package.
-    session.run("flake8", PACKAGE)
-    # Execute the flake8 linter on this file.
-    session.run("flake8", __file__)
-
-
-@nox.session
-def black(session: nox.sessions.Session):
-    """
-    Perform black format checking of the code-base.
-
-    Parameters
-    ----------
-    session: object
-        A `nox.sessions.Session` object.
-
-    """
-    # Pip install the session requirements.
-    session.install("black==22.3.0")
-    # Execute the black format checker on the package.
-    session.run("black", "--check", PACKAGE)
-    # Execute the black format checker on this file.
-    session.run("black", "--check", __file__)
-
-
 @nox.session(python=PY_VER, venv_backend="conda")
 def tests(session: nox.sessions.Session):
     """

--- a/requirements/py310.yml
+++ b/requirements/py310.yml
@@ -19,11 +19,7 @@ dependencies:
 
 # Test dependencies.
   - asv
-  - black=22.3.0
   - codecov
-  - flake8
-  - flake8-docstrings
-  - flake8-import-order
   - nox
   - pre-commit
   - pytest

--- a/requirements/py38.yml
+++ b/requirements/py38.yml
@@ -19,11 +19,7 @@ dependencies:
 
 # Test dependencies.
   - asv
-  - black=22.3.0
   - codecov
-  - flake8
-  - flake8-docstrings
-  - flake8-import-order
   - nox
   - pre-commit
   - pytest

--- a/requirements/py39.yml
+++ b/requirements/py39.yml
@@ -19,11 +19,7 @@ dependencies:
 
 # Test dependencies.
   - asv
-  - black=22.3.0
   - codecov
-  - flake8
-  - flake8-docstrings
-  - flake8-import-order
   - nox
   - pre-commit
   - pytest


### PR DESCRIPTION
In line with Iris, this PR proposes relying purely on [pre-commit.ci](https://pre-commit.ci/) (already enabled on this repo) for linting tasks, doing away with independently managed Nox sessions.

This reduces duplication, and removes the risk of divergence between the Nox sessions and the pre-commit setup (which recently caused [this CI failure](https://github.com/SciTools-incubator/iris-esmf-regrid/pull/235/checks?check_run_id=11157987258) - different linter versions were insisting on different standards).

Iris' decision-making history:

* Use pre-commit instead of an independent setup:
  SciTools/iris#4181
* Rely purely on pre-commit.ci without an additional Nox session:
  SciTools/iris#4503