### PR TITLE
Fix non-functional `import ESMF` after `esmpy>=8.4`

### DIFF
--- a/esmf_regrid/_esmf_sdo.py
+++ b/esmf_regrid/_esmf_sdo.py
@@ -3,7 +3,14 @@
 from abc import ABC, abstractmethod
 
 import cartopy.crs as ccrs
-import ESMF
+try:
+    import esmpy
+except ImportError as exc:
+    # Prior to v8.4.0, `esmpy`` could be imported as `ESMF`.
+    try:
+        import ESMF as esmpy  # noqa: N811
+    except ImportError:
+        raise exc
 import numpy as np
 import scipy.sparse
 

--- a/esmf_regrid/_esmf_sdo.py
+++ b/esmf_regrid/_esmf_sdo.py
@@ -3,6 +3,7 @@
 from abc import ABC, abstractmethod
 
 import cartopy.crs as ccrs
+
 try:
     import esmpy
 except ImportError as exc:

--- a/esmf_regrid/_esmf_sdo.py
+++ b/esmf_regrid/_esmf_sdo.py
@@ -3,7 +3,6 @@
 from abc import ABC, abstractmethod
 
 import cartopy.crs as ccrs
-
 try:
     import esmpy
 except ImportError as exc:

--- a/esmf_regrid/_esmf_sdo.py
+++ b/esmf_regrid/_esmf_sdo.py
@@ -1,4 +1,4 @@
-"""Provides representations of ESMF's Spatial Discretisation Objects."""
+"""Provides representations of ESMF/esmpy's Spatial Discretisation Objects."""
 
 from abc import ABC, abstractmethod
 
@@ -35,7 +35,7 @@ class SDO(ABC):
     def make_esmf_field(self):
         """Return an ESMF field representing the spatial discretisation object."""
         sdo = self._make_esmf_sdo()
-        field = ESMF.Field(sdo, **self._field_kwargs)
+        field = esmpy.Field(sdo, **self._field_kwargs)
         return field
 
     @property
@@ -201,7 +201,7 @@ class GridInfo(SDO):
         super().__init__(
             shape=shape,
             index_offset=1,
-            field_kwargs={"staggerloc": ESMF.StaggerLoc.CENTER},
+            field_kwargs={"staggerloc": esmpy.StaggerLoc.CENTER},
         )
 
     def _as_esmf_info(self):
@@ -264,7 +264,7 @@ class GridInfo(SDO):
         ) = info
 
         if circular:
-            grid = ESMF.Grid(
+            grid = esmpy.Grid(
                 shape,
                 pole_kind=[1, 1],
                 num_peri_dims=1,
@@ -272,27 +272,27 @@ class GridInfo(SDO):
                 pole_dim=0,
             )
         else:
-            grid = ESMF.Grid(shape, pole_kind=[1, 1])
+            grid = esmpy.Grid(shape, pole_kind=[1, 1])
 
-        grid.add_coords(staggerloc=ESMF.StaggerLoc.CORNER)
-        grid_corner_x = grid.get_coords(0, staggerloc=ESMF.StaggerLoc.CORNER)
+        grid.add_coords(staggerloc=esmpy.StaggerLoc.CORNER)
+        grid_corner_x = grid.get_coords(0, staggerloc=esmpy.StaggerLoc.CORNER)
         grid_corner_x[:] = truecornerlons
-        grid_corner_y = grid.get_coords(1, staggerloc=ESMF.StaggerLoc.CORNER)
+        grid_corner_y = grid.get_coords(1, staggerloc=esmpy.StaggerLoc.CORNER)
         grid_corner_y[:] = truecornerlats
 
         # Grid center points are added here, this is not necessary for
         # conservative area weighted regridding
         if self.center:
-            grid.add_coords(staggerloc=ESMF.StaggerLoc.CENTER)
-            grid_center_x = grid.get_coords(0, staggerloc=ESMF.StaggerLoc.CENTER)
+            grid.add_coords(staggerloc=esmpy.StaggerLoc.CENTER)
+            grid_center_x = grid.get_coords(0, staggerloc=esmpy.StaggerLoc.CENTER)
             grid_center_x[:] = truecenterlons
-            grid_center_y = grid.get_coords(1, staggerloc=ESMF.StaggerLoc.CENTER)
+            grid_center_y = grid.get_coords(1, staggerloc=esmpy.StaggerLoc.CENTER)
             grid_center_y[:] = truecenterlats
 
         if areas is not None:
-            grid.add_item(ESMF.GridItem.AREA, staggerloc=ESMF.StaggerLoc.CENTER)
+            grid.add_item(esmpy.GridItem.AREA, staggerloc=esmpy.StaggerLoc.CENTER)
             grid_areas = grid.get_item(
-                ESMF.GridItem.AREA, staggerloc=ESMF.StaggerLoc.CENTER
+                esmpy.GridItem.AREA, staggerloc=esmpy.StaggerLoc.CENTER
             )
             grid_areas[:] = areas.T
 

--- a/esmf_regrid/_esmf_sdo.py
+++ b/esmf_regrid/_esmf_sdo.py
@@ -2,8 +2,8 @@
 
 from abc import ABC, abstractmethod
 
+# fmt: off
 import cartopy.crs as ccrs
-
 try:
     import esmpy
 except ImportError as exc:
@@ -14,6 +14,7 @@ except ImportError as exc:
         raise exc
 import numpy as np
 import scipy.sparse
+# fmt: on
 
 
 class SDO(ABC):

--- a/esmf_regrid/esmf_regridder.py
+++ b/esmf_regrid/esmf_regridder.py
@@ -1,4 +1,4 @@
-"""Provides ESMF representations of grids/UGRID meshes and a modified regridder."""
+"""Provides ESMF/esmpy representations of grids/UGRID meshes and a modified regridder."""
 
 try:
     import esmpy
@@ -22,15 +22,15 @@ __all__ = [
 
 
 def _get_regrid_weights_dict(src_field, tgt_field, regrid_method):
-    regridder = ESMF.Regrid(
+    regridder = esmpy.Regrid(
         src_field,
         tgt_field,
         ignore_degenerate=True,
         regrid_method=regrid_method,
-        unmapped_action=ESMF.UnmappedAction.IGNORE,
+        unmapped_action=esmpy.UnmappedAction.IGNORE,
         # Choosing the norm_type DSTAREA allows for mdtol type operations
         # to be performed using the weights information later on.
-        norm_type=ESMF.NormType.DSTAREA,
+        norm_type=esmpy.NormType.DSTAREA,
         factors=True,
     )
     # Without specifying deep_copy=true, the information in weights_dict
@@ -91,9 +91,9 @@ class Regridder:
         self.tgt = tgt
 
         if method == "conservative":
-            esmf_regrid_method = ESMF.RegridMethod.CONSERVE
+            esmf_regrid_method = esmpy.RegridMethod.CONSERVE
         elif method == "bilinear":
-            esmf_regrid_method = ESMF.RegridMethod.BILINEAR
+            esmf_regrid_method = esmpy.RegridMethod.BILINEAR
         else:
             raise ValueError(
                 f"method must be either 'bilinear' or 'conservative', got '{method}'."
@@ -102,7 +102,7 @@ class Regridder:
 
         self.esmf_regrid_version = esmf_regrid.__version__
         if precomputed_weights is None:
-            self.esmf_version = ESMF.__version__
+            self.esmf_version = esmpy.__version__
             weights_dict = _get_regrid_weights_dict(
                 src.make_esmf_field(),
                 tgt.make_esmf_field(),

--- a/esmf_regrid/esmf_regridder.py
+++ b/esmf_regrid/esmf_regridder.py
@@ -1,6 +1,13 @@
 """Provides ESMF representations of grids/UGRID meshes and a modified regridder."""
 
-import ESMF
+try:
+    import esmpy
+except ImportError as exc:
+    # Prior to v8.4.0, `esmpy`` could be imported as `ESMF`.
+    try:
+        import ESMF as esmpy  # noqa: N811
+    except ImportError:
+        raise exc
 import numpy as np
 from numpy import ma
 import scipy.sparse

--- a/esmf_regrid/experimental/unstructured_regrid.py
+++ b/esmf_regrid/experimental/unstructured_regrid.py
@@ -1,6 +1,13 @@
 """Provides :mod:`ESMF` representations of UGRID meshes."""
 
-import ESMF
+try:
+    import esmpy
+except ImportError as exc:
+    # Prior to v8.4.0, `esmpy`` could be imported as `ESMF`.
+    try:
+        import ESMF as esmpy  # noqa: N811
+    except ImportError:
+        raise exc
 import numpy as np
 
 from .._esmf_sdo import SDO

--- a/esmf_regrid/experimental/unstructured_regrid.py
+++ b/esmf_regrid/experimental/unstructured_regrid.py
@@ -1,4 +1,4 @@
-"""Provides :mod:`ESMF` representations of UGRID meshes."""
+"""Provides :mod:`ESMF/esmpy` representations of UGRID meshes."""
 
 try:
     import esmpy
@@ -77,10 +77,10 @@ class MeshInfo(SDO):
         self.areas = areas
         self.elem_coords = elem_coords
         if location == "face":
-            field_kwargs = {"meshloc": ESMF.MeshLoc.ELEMENT}
+            field_kwargs = {"meshloc": esmpy.MeshLoc.ELEMENT}
             shape = (len(face_node_connectivity),)
         elif location == "node":
-            field_kwargs = {"meshloc": ESMF.MeshLoc.NODE}
+            field_kwargs = {"meshloc": esmpy.MeshLoc.NODE}
             shape = (len(node_coords),)
         else:
             raise ValueError(
@@ -136,8 +136,8 @@ class MeshInfo(SDO):
         ) = info
         # ESMF can handle other dimensionalities, but we are unlikely
         # to make such a use of ESMF
-        emesh = ESMF.Mesh(
-            parametric_dim=2, spatial_dim=2, coord_sys=ESMF.CoordSys.SPH_DEG
+        emesh = esmpy.Mesh(
+            parametric_dim=2, spatial_dim=2, coord_sys=esmpy.CoordSys.SPH_DEG
         )
 
         emesh.add_nodes(num_node, nodeId, nodeCoord, nodeOwner)

--- a/esmf_regrid/tests/integration/esmf_regridder/test_Regridder.py
+++ b/esmf_regrid/tests/integration/esmf_regridder/test_Regridder.py
@@ -1,6 +1,13 @@
 """Unit tests for :class:`esmf_regrid.esmf_regridder.Regridder`."""
 
-import ESMF
+try:
+    import esmpy
+except ImportError as exc:
+    # Prior to v8.4.0, `esmpy`` could be imported as `ESMF`.
+    try:
+        import ESMF as esmpy  # noqa: N811
+    except ImportError:
+        raise exc
 import numpy as np
 from numpy import ma
 

--- a/esmf_regrid/tests/integration/esmf_regridder/test_Regridder.py
+++ b/esmf_regrid/tests/integration/esmf_regridder/test_Regridder.py
@@ -40,9 +40,9 @@ def test_esmpy_normalisation():
     lon, lat, lon_bounds, lat_bounds = make_grid_args(2, 3)
     src_grid = GridInfo(lon, lat, lon_bounds, lat_bounds)
     src_esmpy_grid = src_grid._make_esmf_sdo()
-    src_esmpy_grid.add_item(ESMF.GridItem.MASK, staggerloc=ESMF.StaggerLoc.CENTER)
+    src_esmpy_grid.add_item(esmpy.GridItem.MASK, staggerloc=esmpy.StaggerLoc.CENTER)
     src_esmpy_grid.mask[0][...] = src_mask
-    src_field = ESMF.Field(src_esmpy_grid)
+    src_field = esmpy.Field(src_esmpy_grid)
     src_field.data[...] = src_data
 
     lon, lat, lon_bounds, lat_bounds = make_grid_args(3, 2)
@@ -53,16 +53,16 @@ def test_esmpy_normalisation():
 
     regridding_kwargs = {
         "ignore_degenerate": True,
-        "regrid_method": ESMF.RegridMethod.CONSERVE,
-        "unmapped_action": ESMF.UnmappedAction.IGNORE,
+        "regrid_method": esmpy.RegridMethod.CONSERVE,
+        "unmapped_action": esmpy.UnmappedAction.IGNORE,
         "factors": True,
         "src_mask_values": [1],
     }
-    esmpy_fracarea_regridder = ESMF.Regrid(
-        src_field, tgt_field, norm_type=ESMF.NormType.FRACAREA, **regridding_kwargs
+    esmpy_fracarea_regridder = esmpy.Regrid(
+        src_field, tgt_field, norm_type=esmpy.NormType.FRACAREA, **regridding_kwargs
     )
-    esmpy_dstarea_regridder = ESMF.Regrid(
-        src_field, tgt_field, norm_type=ESMF.NormType.DSTAREA, **regridding_kwargs
+    esmpy_dstarea_regridder = esmpy.Regrid(
+        src_field, tgt_field, norm_type=esmpy.NormType.DSTAREA, **regridding_kwargs
     )
 
     tgt_field_dstarea = esmpy_dstarea_regridder(src_field, tgt_field)


### PR DESCRIPTION
This is @bouweandela 's elegant solution from https://github.com/ESMValGroup/ESMValCore/pull/1876 implemented here so `iris-esmf-regrid` can support the newer esmpy, and implicitly allow support for Python=3.11, implicitly allowing us to have Python=3.11 too :grin: 

Closes https://github.com/SciTools-incubator/iris-esmf-regrid/issues/227