### PR TITLE
Add env vars to sphinx config

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # iris-esmf-regrid
 
 [![Build Status](https://api.cirrus-ci.com/github/SciTools-incubator/iris-esmf-regrid.svg)](https://cirrus-ci.com/github/SciTools-incubator/iris-esmf-regrid)
+[![Documentation Status](https://readthedocs.org/projects/iris-esmf-regrid/badge/?version=latest)](https://iris-esmf-regrid.readthedocs.io/en/latest/?badge=latest)
 [![pre-commit.ci status](https://results.pre-commit.ci/badge/github/SciTools-incubator/iris-esmf-regrid/main.svg)](https://results.pre-commit.ci/latest/github/SciTools-incubator/iris-esmf-regrid/master)
 [![codecov](https://codecov.io/gh/SciTools-incubator/iris-esmf-regrid/branch/main/graph/badge.svg?token=PKBXEHOZFT)](https://codecov.io/gh/SciTools-incubator/iris-esmf-regrid)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)

--- a/docs/src/conf.py
+++ b/docs/src/conf.py
@@ -18,8 +18,8 @@ source_code_root = (Path(__file__).parents[2]).absolute()
 sys.path.append(str(source_code_root))
 
 on_rtd = os.environ.get("READTHEDOCS", None) == "True"
-rtd_version = os.environ.get("READTHEDOCS_VERSION", "latest")
 if on_rtd:
+    rtd_version = os.environ.get("READTHEDOCS_VERSION", "latest")
     rtd_project = os.environ.get("READTHEDOCS_PROJECT")
     rtd_conda_prefix = f"/home/docs/checkouts/readthedocs.org/user_builds/{rtd_project}/conda/{rtd_version}"
     os.environ["ESMFMKFILE"] = f"{rtd_conda_prefix}/lib/esmf.mk"

--- a/docs/src/conf.py
+++ b/docs/src/conf.py
@@ -5,6 +5,7 @@ Created originally using sphinx-quickstart on 2022-02-21.
 """
 
 from datetime import datetime
+import os
 from pathlib import Path
 import sys
 
@@ -29,6 +30,15 @@ author = "iris-esmf-regrid Contributors"
 
 # The full version, including alpha/beta/rc tags
 release = esmf_r_version
+
+on_rtd = os.environ.get("READTHEDOCS", None) == "True"
+rtd_version = os.environ.get("READTHEDOCS_VERSION", "latest")
+if on_rtd:
+    rtd_project = os.environ.get("READTHEDOCS_PROJECT")
+    rtd_conda_prefix = f"/home/docs/checkouts/readthedocs.org/user_builds/{rtd_project}/conda/{rtd_version}"
+    os.environ["ESMFMKFILE"] = f"{rtd_conda_prefix}/lib/esmf.mk"
+    os.environ["PROJ_DATA"] = f"{rtd_conda_prefix}/share/proj"
+    os.environ["PROJ_NETWORK"] = "OFF"
 
 
 # -- General configuration ---------------------------------------------------

--- a/docs/src/conf.py
+++ b/docs/src/conf.py
@@ -17,6 +17,15 @@ import sys
 source_code_root = (Path(__file__).parents[2]).absolute()
 sys.path.append(str(source_code_root))
 
+on_rtd = os.environ.get("READTHEDOCS", None) == "True"
+rtd_version = os.environ.get("READTHEDOCS_VERSION", "latest")
+if on_rtd:
+    rtd_project = os.environ.get("READTHEDOCS_PROJECT")
+    rtd_conda_prefix = f"/home/docs/checkouts/readthedocs.org/user_builds/{rtd_project}/conda/{rtd_version}"
+    os.environ["ESMFMKFILE"] = f"{rtd_conda_prefix}/lib/esmf.mk"
+    os.environ["PROJ_DATA"] = f"{rtd_conda_prefix}/share/proj"
+    os.environ["PROJ_NETWORK"] = "OFF"
+
 
 # -- Project information -----------------------------------------------------
 
@@ -30,15 +39,6 @@ author = "iris-esmf-regrid Contributors"
 
 # The full version, including alpha/beta/rc tags
 release = esmf_r_version
-
-on_rtd = os.environ.get("READTHEDOCS", None) == "True"
-rtd_version = os.environ.get("READTHEDOCS_VERSION", "latest")
-if on_rtd:
-    rtd_project = os.environ.get("READTHEDOCS_PROJECT")
-    rtd_conda_prefix = f"/home/docs/checkouts/readthedocs.org/user_builds/{rtd_project}/conda/{rtd_version}"
-    os.environ["ESMFMKFILE"] = f"{rtd_conda_prefix}/lib/esmf.mk"
-    os.environ["PROJ_DATA"] = f"{rtd_conda_prefix}/share/proj"
-    os.environ["PROJ_NETWORK"] = "OFF"
 
 
 # -- General configuration ---------------------------------------------------


### PR DESCRIPTION
Readthedocs doesn't `activate` Conda environments and also doesn't use `conda run`. As a consequence, crucial environment variables are not set, preventing the successful building of the documentation.

This PR adds the environment variables in Sphinx' `conf.py`, providing a workaround for that problem. This might need to be updated in the future if either different variables are needed (e.g. Proj recently moved from `PROJ_LIB` to `PROJ_DATA`), or if Readthedocs addresses this, e.g. in readthedocs/readthedocs.org#5339.

Fixes #251