### PR TITLE
Add nearest neighbour regridding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   [@stephenworsley](https://github.com/stephenworsley) with extensive review
   work from [@trexfeathers](https://github.com/trexfeathers)
 
+- [PR#266](https://github.com/SciTools-incubator/iris-esmf-regrid/pull/266)
+  Added Nearest neighbour regridding.
+  [@stephenworsley](https://github.com/stephenworsley)
+  [@HGWright](https://github.com/HGWright)
+
 ### Changed
 
 - [PR#198](https://github.com/SciTools-incubator/iris-esmf-regrid/pull/198)

--- a/esmf_regrid/esmf_regridder.py
+++ b/esmf_regrid/esmf_regridder.py
@@ -76,9 +76,10 @@ class Regridder:
             Data output by this regridder will be a :class:`numpy.ndarray` whose
             shape is compatible with ``tgt``.
         method : str
-            Either "conservative" or "bilinear". Corresponds to the :mod:`esmpy` methods
-            :attr:`~esmpy.api.constants.RegridMethod.CONSERVE` or
-            :attr:`~esmpy.api.constants.RegridMethod.BILINEAR` used to calculate weights.
+            Either "conservative", "bilinear" or "nearest". Corresponds to the :mod:`esmpy` methods
+            :attr:`~esmpy.api.constants.RegridMethod.CONSERVE`,
+            :attr:`~esmpy.api.constants.RegridMethod.BILINEAR` or
+            :attr:`~esmpy.api.constants.RegridMethod.NEAREST_STOD` used to calculate weights.
         precomputed_weights : :class:`scipy.sparse.spmatrix`, optional
             If ``None``, :mod:`esmpy` will be used to
             calculate regridding weights. Otherwise, :mod:`esmpy` will be bypassed
@@ -91,9 +92,11 @@ class Regridder:
             esmf_regrid_method = esmpy.RegridMethod.CONSERVE
         elif method == "bilinear":
             esmf_regrid_method = esmpy.RegridMethod.BILINEAR
+        elif method == "nearest":
+            esmf_regrid_method = esmpy.RegridMethod.NEAREST_STOD
         else:
             raise ValueError(
-                f"method must be either 'bilinear' or 'conservative', got '{method}'."
+                f"method must be either 'bilinear', 'conservative' or 'nearest', got '{method}'."
             )
         self.method = method
 

--- a/esmf_regrid/esmf_regridder.py
+++ b/esmf_regrid/esmf_regridder.py
@@ -10,6 +10,7 @@ from ._esmf_sdo import GridInfo, RefinedGridInfo
 
 __all__ = [
     "GridInfo",
+    "RefinedGridInfo",
     "Regridder",
 ]
 

--- a/esmf_regrid/experimental/unstructured_scheme.py
+++ b/esmf_regrid/experimental/unstructured_scheme.py
@@ -128,9 +128,10 @@ class MeshToGridESMFRegridder(_ESMFRegridder):
             if all the contributing elements of data are masked. Defaults to 1
             for conservative regregridding and 0 for bilinear regridding.
         method : str, default="conservative"
-            Either "conservative" or "bilinear". Corresponds to the :mod:`esmpy` methods
-            :attr:`~esmpy.api.constants.RegridMethod.CONSERVE` or
-            :attr:`~esmpy.api.constants.RegridMethod.BILINEAR` used to calculate weights.
+            Either "conservative", "bilinear" or "nearest". Corresponds to the :mod:`esmpy`
+            methods :attr:`~esmpy.api.constants.RegridMethod.CONSERVE` or
+            :attr:`~esmpy.api.constants.RegridMethod.BILINEAR` or
+            :attr:`~esmpy.api.constants.RegridMethod.NEAREST` used to calculate weights.
         precomputed_weights : :class:`scipy.sparse.spmatrix`, optional
             If ``None``, :mod:`esmpy` will be used to
             calculate regridding weights. Otherwise, :mod:`esmpy` will be bypassed
@@ -298,9 +299,10 @@ class GridToMeshESMFRegridder(_ESMFRegridder):
             if all the contributing elements of data are masked. Defaults to 1
             for conservative regregridding and 0 for bilinear regridding.
         method : str, default="conservative"
-            Either "conservative" or "bilinear". Corresponds to the :mod:`esmpy` methods
-            :attr:`~esmpy.api.constants.RegridMethod.CONSERVE` or
-            :attr:`~esmpy.api.constants.RegridMethod.BILINEAR` used to calculate weights.
+            Either "conservative", "bilinear" or "nearest". Corresponds to the :mod:`esmpy`
+            methods :attr:`~esmpy.api.constants.RegridMethod.CONSERVE` or
+            :attr:`~esmpy.api.constants.RegridMethod.BILINEAR` or
+            :attr:`~esmpy.api.constants.RegridMethod.NEAREST` used to calculate weights.
         precomputed_weights : :class:`scipy.sparse.spmatrix`, optional
             If ``None``, :mod:`esmpy` will be used to
             calculate regridding weights. Otherwise, :mod:`esmpy` will be bypassed

--- a/esmf_regrid/experimental/unstructured_scheme.py
+++ b/esmf_regrid/experimental/unstructured_scheme.py
@@ -56,9 +56,10 @@ def regrid_unstructured_to_rectilinear(
         will mean the resulting element will be masked if and only if all the
         overlapping cells of ``src_cube`` are masked.
     method : str, default="conservative"
-        Either "conservative" or "bilinear". Corresponds to the :mod:`esmpy` methods
+        Either "conservative", "bilinear" or "nearest". Corresponds to the :mod:`esmpy` methods
         :attr:`~esmpy.api.constants.RegridMethod.CONSERVE` or
-        :attr:`~esmpy.api.constants.RegridMethod.BILINEAR` used to calculate weights.
+        :attr:`~esmpy.api.constants.RegridMethod.BILINEAR` or
+        :attr:`~esmpy.api.constants.RegridMethod.NEAREST` used to calculate weights.
     tgt_resolution : int, optional
         If present, represents the amount of latitude slices per cell
         given to ESMF for calculation.
@@ -219,9 +220,10 @@ def regrid_rectilinear_to_unstructured(
         will mean the resulting element will be masked if and only if all the
         overlapping cells of the ``src_cube`` are masked.
     method : str, default="conservative"
-        Either "conservative" or "bilinear". Corresponds to the :mod:`esmpy` methods
+        Either "conservative", "bilinear" or "nearest". Corresponds to the :mod:`esmpy` methods
         :attr:`~esmpy.api.constants.RegridMethod.CONSERVE` or
-        :attr:`~esmpy.api.constants.RegridMethod.BILINEAR` used to calculate weights.
+        :attr:`~esmpy.api.constants.RegridMethod.BILINEAR` or
+        :attr:`~esmpy.api.constants.RegridMethod.NEAREST` used to calculate weights.
     src_resolution : int, optional
         If present, represents the amount of latitude slices per cell
         given to ESMF for calculation.

--- a/esmf_regrid/experimental/unstructured_scheme.py
+++ b/esmf_regrid/experimental/unstructured_scheme.py
@@ -154,8 +154,8 @@ class MeshToGridESMFRegridder(_ESMFRegridder):
         Raises
         ------
         ValueError
-            If use_src_mask or use_tgt_mask are true while the masks on src or
-            tgt respectively are not constant over non-horizontal dimensions.
+            If ``use_src_mask`` or ``use_tgt_mask`` are True while the masks on ``src``
+            or ``tgt`` respectively are not constant over non-horizontal dimensions.
 
 
         """
@@ -324,8 +324,8 @@ class GridToMeshESMFRegridder(_ESMFRegridder):
         Raises
         ------
         ValueError
-            If use_src_mask or use_tgt_mask are true while the masks on src or
-            tgt respectively are not constant over non-horizontal dimensions.
+            If ``use_src_mask`` or ``use_tgt_mask`` are True while the masks on ``src``
+            or ``tgt`` respectively are not constant over non-horizontal dimensions.
 
         """
         if tgt.mesh is None:

--- a/esmf_regrid/experimental/unstructured_scheme.py
+++ b/esmf_regrid/experimental/unstructured_scheme.py
@@ -151,6 +151,12 @@ class MeshToGridESMFRegridder(_ESMFRegridder):
             in ``tgt``. If False, no mask will be taken and all points
             will be used in weights calculation.
 
+        Raises
+        ------
+        ValueError
+            If use_src_mask or use_tgt_mask are true while the masks on src or
+            tgt respectively are not constant over non-horizontal dimensions.
+
 
         """
         if src.mesh is None:
@@ -314,6 +320,12 @@ class GridToMeshESMFRegridder(_ESMFRegridder):
             a boolean value. If True, this array is taken from the mask on the data
             in ``tgt``. If False, no mask will be taken and all points
             will be used in weights calculation.
+
+        Raises
+        ------
+        ValueError
+            If use_src_mask or use_tgt_mask are true while the masks on src or
+            tgt respectively are not constant over non-horizontal dimensions.
 
         """
         if tgt.mesh is None:

--- a/esmf_regrid/schemes.py
+++ b/esmf_regrid/schemes.py
@@ -885,6 +885,12 @@ class ESMFAreaWeighted:
                 ... where ``cube`` is a :class:`~iris.cube.Cube` with the same
                 grid as ``src_grid`` that is to be regridded to the grid of
                 ``tgt_grid``.
+
+        Raises
+        ------
+        ValueError
+            If use_src_mask or use_tgt_mask are true while the masks on src_grid or
+            tgt_grid respectively are not constant over non-horizontal dimensions.
         """
         if use_src_mask is None:
             use_src_mask = self.use_src_mask
@@ -961,6 +967,12 @@ class ESMFBilinear:
                 ... where ``cube`` is a :class:`~iris.cube.Cube` with the same
                 grid as ``src_grid`` that is to be regridded to the grid of
                 ``tgt_grid``.
+
+        Raises
+        ------
+        ValueError
+            If use_src_mask or use_tgt_mask are true while the masks on src_grid or
+            tgt_grid respectively are not constant over non-horizontal dimensions.
         """
         if use_src_mask is None:
             use_src_mask = self.use_src_mask
@@ -987,8 +999,10 @@ class ESMFNearest:
     -----
     By default, masked data is handled by masking the result when the
     nearest source point is masked, however, if `use_src_mask` is True, then
-    the nearest unmasked point is used instead. This only works when the mask is
-    constant over all non-horizontal dimensions otherwise an error is thrown.
+    the nearest unmasked point is used instead. This differs from other regridding
+    methods where `use_src_mask` has no effect on the mathematics. Like other
+    methods, when `use_src_mask` is True, the mask must be constant over all
+    non-horizontal dimensions otherwise an error is thrown.
 
     When two source points are a constant distance from a target point,
     the decision for which point is used is based on the indexing which ESMF gives
@@ -1043,6 +1057,12 @@ class ESMFNearest:
                 ... where ``cube`` is a :class:`~iris.cube.Cube` with the same
                 grid as ``src_grid`` that is to be regridded to the grid of
                 ``tgt_grid``.
+
+        Raises
+        ------
+        ValueError
+            If use_src_mask or use_tgt_mask are true while the masks on src_grid or
+            tgt_grid respectively are not constant over non-horizontal dimensions.
         """
         if use_src_mask is None:
             use_src_mask = self.use_src_mask
@@ -1095,6 +1115,12 @@ class _ESMFRegridder:
             a boolean value. If True, this array is taken from the mask on the data
             in ``src`` or ``tgt``. If False, no mask will be taken and all points will
             be used in weights calculation.
+
+        Raises
+        ------
+        ValueError
+            If use_src_mask or use_tgt_mask are true while the masks on src or tgt respectively
+            are not constant over non-horizontal dimensions.
 
         """
         if method not in ["conservative", "bilinear", "nearest"]:
@@ -1269,6 +1295,12 @@ class ESMFAreaWeightedRegridder(_ESMFRegridder):
             a boolean value. If True, this array is taken from the mask on the data
             in ``src`` or ``tgt``. If False, no mask will be taken and all points will
             be used in weights calculation.
+
+        Raises
+        ------
+        ValueError
+            If use_src_mask or use_tgt_mask are true while the masks on src or tgt respectively
+            are not constant over non-horizontal dimensions.
         """
         kwargs = dict()
         if src_resolution is not None:
@@ -1323,6 +1355,12 @@ class ESMFBilinearRegridder(_ESMFRegridder):
             a boolean value. If True, this array is taken from the mask on the data
             in ``src`` or ``tgt``. If False, no mask will be taken and all points will
             be used in weights calculation.
+
+        Raises
+        ------
+        ValueError
+            If use_src_mask or use_tgt_mask are true while the masks on src or tgt respectively
+            are not constant over non-horizontal dimensions.
         """
         super().__init__(
             src,
@@ -1364,6 +1402,12 @@ class ESMFNearestRegridder(_ESMFRegridder):
             a boolean value. If True, this array is taken from the mask on the data
             in ``src`` or ``tgt``. If False, no mask will be taken and all points will
             be used in weights calculation.
+
+        Raises
+        ------
+        ValueError
+            If use_src_mask or use_tgt_mask are true while the masks on src or tgt respectively
+            are not constant over non-horizontal dimensions.
         """
         super().__init__(
             src,

--- a/esmf_regrid/schemes.py
+++ b/esmf_regrid/schemes.py
@@ -889,8 +889,8 @@ class ESMFAreaWeighted:
         Raises
         ------
         ValueError
-            If use_src_mask or use_tgt_mask are true while the masks on src_grid or
-            tgt_grid respectively are not constant over non-horizontal dimensions.
+            If ``use_src_mask`` or ``use_tgt_mask`` are True while the masks on ``src_grid``
+            or ``tgt_grid`` respectively are not constant over non-horizontal dimensions.
         """
         if use_src_mask is None:
             use_src_mask = self.use_src_mask
@@ -971,8 +971,8 @@ class ESMFBilinear:
         Raises
         ------
         ValueError
-            If use_src_mask or use_tgt_mask are true while the masks on src_grid or
-            tgt_grid respectively are not constant over non-horizontal dimensions.
+            If ``use_src_mask`` or ``use_tgt_mask`` are True while the masks on ``src_grid``
+            or ``tgt_grid`` respectively are not constant over non-horizontal dimensions.
         """
         if use_src_mask is None:
             use_src_mask = self.use_src_mask
@@ -1061,8 +1061,8 @@ class ESMFNearest:
         Raises
         ------
         ValueError
-            If use_src_mask or use_tgt_mask are true while the masks on src_grid or
-            tgt_grid respectively are not constant over non-horizontal dimensions.
+            If ``use_src_mask`` or ``use_tgt_mask`` are True while the masks on ``src_grid``
+            or ``tgt_grid`` respectively are not constant over non-horizontal dimensions.
         """
         if use_src_mask is None:
             use_src_mask = self.use_src_mask
@@ -1119,8 +1119,8 @@ class _ESMFRegridder:
         Raises
         ------
         ValueError
-            If use_src_mask or use_tgt_mask are true while the masks on src or tgt respectively
-            are not constant over non-horizontal dimensions.
+            If ``use_src_mask`` or ``use_tgt_mask`` are True while the masks on ``src``
+            or ``tgt`` respectively are not constant over non-horizontal dimensions.
 
         """
         if method not in ["conservative", "bilinear", "nearest"]:
@@ -1299,8 +1299,8 @@ class ESMFAreaWeightedRegridder(_ESMFRegridder):
         Raises
         ------
         ValueError
-            If use_src_mask or use_tgt_mask are true while the masks on src or tgt respectively
-            are not constant over non-horizontal dimensions.
+            If ``use_src_mask`` or ``use_tgt_mask`` are True while the masks on ``src``
+            or ``tgt`` respectively are not constant over non-horizontal dimensions.
         """
         kwargs = dict()
         if src_resolution is not None:
@@ -1359,8 +1359,8 @@ class ESMFBilinearRegridder(_ESMFRegridder):
         Raises
         ------
         ValueError
-            If use_src_mask or use_tgt_mask are true while the masks on src or tgt respectively
-            are not constant over non-horizontal dimensions.
+            If ``use_src_mask`` or ``use_tgt_mask`` are True while the masks on ``src``
+            or ``tgt`` respectively are not constant over non-horizontal dimensions.
         """
         super().__init__(
             src,
@@ -1406,8 +1406,8 @@ class ESMFNearestRegridder(_ESMFRegridder):
         Raises
         ------
         ValueError
-            If use_src_mask or use_tgt_mask are true while the masks on src or tgt respectively
-            are not constant over non-horizontal dimensions.
+            If ``use_src_mask`` or ``use_tgt_mask`` are True while the masks on ``src``
+            or ``tgt`` respectively are not constant over non-horizontal dimensions.
         """
         super().__init__(
             src,

--- a/esmf_regrid/schemes.py
+++ b/esmf_regrid/schemes.py
@@ -17,6 +17,10 @@ from esmf_regrid.experimental.unstructured_regrid import MeshInfo
 __all__ = [
     "ESMFAreaWeighted",
     "ESMFAreaWeightedRegridder",
+    "ESMFBilinear",
+    "ESMFBilinearRegridder",
+    "ESMFNearest",
+    "ESMFNearestRegridder",
     "regrid_rectilinear_to_rectilinear",
 ]
 

--- a/esmf_regrid/schemes.py
+++ b/esmf_regrid/schemes.py
@@ -961,9 +961,7 @@ class ESMFNearest:
     """
 
     def __init__(self):
-        """
-        Area-weighted scheme for regridding between rectilinear grids.
-        """
+        """Area-weighted scheme for regridding between rectilinear grids."""
         pass
 
     def __repr__(self):

--- a/esmf_regrid/schemes.py
+++ b/esmf_regrid/schemes.py
@@ -983,12 +983,14 @@ class ESMFNearest:
     between horizontal grids/meshes. It uses :mod:`esmpy` to handle
     calculations and allows for different coordinate systems.
 
-    Note that by default, masked data is handled by masking the result when the
+    Notes
+    -----
+    By default, masked data is handled by masking the result when the
     nearest source point is masked, however, if `use_src_mask` is True, then
     the nearest unmasked point is used instead. This only works when the mask is
     constant over all non-horizontal dimensions otherwise an error is thrown.
 
-    Note that when two source points are a constant distance from a target point,
+    When two source points are a constant distance from a target point,
     the decision for which point is used is based on the indexing which ESMF gives
     the points. ESMF describes this decision as somewhat arbitrary:
     https://earthsystemmodeling.org/docs/release/latest/ESMF_refdoc/node3.html#SECTION03023000000000000000
@@ -999,7 +1001,7 @@ class ESMFNearest:
 
     def __init__(self, use_src_mask=False, use_tgt_mask=False):
         """
-        Area-weighted scheme for regridding between rectilinear grids.
+        Nearest neighbour scheme for regridding between rectilinear grids.
 
         Parameters
         ----------
@@ -1081,12 +1083,13 @@ class _ESMFRegridder:
         :attr:`~esmpy.api.constants.RegridMethod.CONSERVE`,
         :attr:`~esmpy.api.constants.RegridMethod.BILINEAR` or
         :attr:`~esmpy.api.constants.RegridMethod.NEAREST_STOD` used to calculate weights.
-        mdtol : float, default=0
+        mdtol : float, default=None
             Tolerance of missing data. The value returned in each element of
             the returned array will be masked if the fraction of masked data
             exceeds ``mdtol``. ``mdtol=0`` means no missing data is tolerated while
             ``mdtol=1`` will mean the resulting element will be masked if and only
-            if all the contributing elements of data are masked.
+            if all the contributing elements of data are masked. If no value is given,
+            this will default to 1 for conservative regridding and 0 otherwise.
         use_src_mask, use_tgt_mask : :obj:`~numpy.typing.ArrayLike` or bool, default=False
             Either an array representing the cells in the source/target to ignore, or else
             a boolean value. If True, this array is taken from the mask on the data

--- a/esmf_regrid/schemes.py
+++ b/esmf_regrid/schemes.py
@@ -937,7 +937,7 @@ class ESMFBilinear:
         """Return a representation of the class."""
         return "ESMFBilinear(mdtol={})".format(self.mdtol)
 
-    def regridder(self, src_grid, tgt_grid):
+    def regridder(self, src_grid, tgt_grid, use_src_mask=None, use_tgt_mask=None):
         """
         Create regridder to perform regridding from ``src_grid`` to ``tgt_grid``.
 
@@ -947,6 +947,12 @@ class ESMFBilinear:
             The :class:`~iris.cube.Cube` defining the source grid.
         tgt_grid : :class:`iris.cube.Cube`
             The :class:`~iris.cube.Cube` defining the target grid.
+        use_src_mask : :obj:`~numpy.typing.ArrayLike` or bool, optional
+            Array describing which elements :mod:`esmpy` will ignore on the src_grid.
+            If True, the mask will be derived from src_grid.
+        use_tgt_mask : :obj:`~numpy.typing.ArrayLike` or bool, optional
+            Array describing which elements :mod:`esmpy` will ignore on the tgt_grid.
+            If True, the mask will be derived from tgt_grid.
 
         Returns
         -------
@@ -956,6 +962,10 @@ class ESMFBilinear:
                 grid as ``src_grid`` that is to be regridded to the grid of
                 ``tgt_grid``.
         """
+        if use_src_mask is None:
+            use_src_mask = self.use_src_mask
+        if use_tgt_mask is None:
+            use_tgt_mask = self.use_tgt_mask
         return ESMFBilinearRegridder(
             src_grid,
             tgt_grid,
@@ -988,7 +998,18 @@ class ESMFNearest:
     """
 
     def __init__(self, use_src_mask=False, use_tgt_mask=False):
-        """Area-weighted scheme for regridding between rectilinear grids."""
+        """
+        Area-weighted scheme for regridding between rectilinear grids.
+
+        Parameters
+        ----------
+        use_src_mask : bool, default=False
+            If True, derive a mask from source cube which will tell :mod:`esmpy`
+            which points to ignore.
+        use_tgt_mask : bool, default=False
+            If True, derive a mask from target cube which will tell :mod:`esmpy`
+            which points to ignore.
+        """
         self.use_src_mask = use_src_mask
         self.use_tgt_mask = use_tgt_mask
 
@@ -996,7 +1017,7 @@ class ESMFNearest:
         """Return a representation of the class."""
         return "ESMFNearest()"
 
-    def regridder(self, src_grid, tgt_grid):
+    def regridder(self, src_grid, tgt_grid, use_src_mask=None, use_tgt_mask=None):
         """
         Create regridder to perform regridding from ``src_grid`` to ``tgt_grid``.
 
@@ -1006,12 +1027,12 @@ class ESMFNearest:
             The :class:`~iris.cube.Cube` defining the source grid.
         tgt_grid : :class:`iris.cube.Cube`
             The :class:`~iris.cube.Cube` defining the target grid.
-        use_src_mask : bool, default=False
-            If True, derive a mask from source cube which will tell :mod:`esmpy`
-            which points to ignore.
-        use_tgt_mask : bool, default=False
-            If True, derive a mask from target cube which will tell :mod:`esmpy`
-            which points to ignore.
+        use_src_mask : :obj:`~numpy.typing.ArrayLike` or bool, optional
+            Array describing which elements :mod:`esmpy` will ignore on the src_grid.
+            If True, the mask will be derived from src_grid.
+        use_tgt_mask : :obj:`~numpy.typing.ArrayLike` or bool, optional
+            Array describing which elements :mod:`esmpy` will ignore on the tgt_grid.
+            If True, the mask will be derived from tgt_grid.
 
         Returns
         -------
@@ -1021,6 +1042,10 @@ class ESMFNearest:
                 grid as ``src_grid`` that is to be regridded to the grid of
                 ``tgt_grid``.
         """
+        if use_src_mask is None:
+            use_src_mask = self.use_src_mask
+        if use_tgt_mask is None:
+            use_tgt_mask = self.use_tgt_mask
         return ESMFNearestRegridder(
             src_grid,
             tgt_grid,

--- a/esmf_regrid/tests/unit/experimental/io/test_round_tripping.py
+++ b/esmf_regrid/tests/unit/experimental/io/test_round_tripping.py
@@ -117,9 +117,10 @@ def _make_mesh_to_grid_regridder(
     return rg, src
 
 
-def test_GridToMeshESMFRegridder_round_trip(tmp_path):
+@pytest.mark.parametrize("method", ["conservative", "bilinear", "nearest"])
+def test_GridToMeshESMFRegridder_round_trip(tmp_path, method):
     """Test save/load round tripping for `GridToMeshESMFRegridder`."""
-    original_rg, src = _make_grid_to_mesh_regridder(circular=True)
+    original_rg, src = _make_grid_to_mesh_regridder(method=method, circular=True)
     filename = tmp_path / "regridder.nc"
     save_regridder(original_rg, filename)
     loaded_rg = load_regridder(str(filename))
@@ -156,66 +157,26 @@ def test_GridToMeshESMFRegridder_round_trip(tmp_path):
         == loaded_rg.regridder.esmf_regrid_version
     )
 
-    # Ensure resolution is equal.
-    assert original_rg.resolution == loaded_rg.resolution
-    original_res_rg, _ = _make_grid_to_mesh_regridder(resolution=8)
-    res_filename = tmp_path / "regridder_res.nc"
-    save_regridder(original_res_rg, res_filename)
-    loaded_res_rg = load_regridder(str(res_filename))
-    assert original_res_rg.resolution == loaded_res_rg.resolution
-    assert (
-        original_res_rg.regridder.src.resolution
-        == loaded_res_rg.regridder.src.resolution
-    )
+    if method == "conservative":
+        # Ensure resolution is equal.
+        assert original_rg.resolution == loaded_rg.resolution
+        original_res_rg, _ = _make_grid_to_mesh_regridder(method=method, resolution=8)
+        res_filename = tmp_path / "regridder_res.nc"
+        save_regridder(original_res_rg, res_filename)
+        loaded_res_rg = load_regridder(str(res_filename))
+        assert original_res_rg.resolution == loaded_res_rg.resolution
+        assert (
+            original_res_rg.regridder.src.resolution
+            == loaded_res_rg.regridder.src.resolution
+        )
 
     # Ensure grid equality for non-circular coords.
-    original_nc_rg, _ = _make_grid_to_mesh_regridder(circular=False)
+    original_nc_rg, _ = _make_grid_to_mesh_regridder(method=method, circular=False)
     nc_filename = tmp_path / "non_circular_regridder.nc"
     save_regridder(original_nc_rg, nc_filename)
     loaded_nc_rg = load_regridder(str(nc_filename))
     assert original_nc_rg.grid_x == loaded_nc_rg.grid_x
     assert original_nc_rg.grid_y == loaded_nc_rg.grid_y
-
-
-@pytest.mark.parametrize("method", ["bilinear", "nearest"])
-def test_GridToMeshESMFRegridder_other_method_round_trip(tmp_path, method):
-    """Test save/load round tripping for `GridToMeshESMFRegridder`."""
-    original_rg, src = _make_grid_to_mesh_regridder(method=method)
-    filename = tmp_path / "regridder.nc"
-    save_regridder(original_rg, filename)
-    loaded_rg = load_regridder(str(filename))
-
-    assert original_rg.location == loaded_rg.location
-    assert original_rg.method == loaded_rg.method
-    assert original_rg.mdtol == loaded_rg.mdtol
-    assert original_rg.grid_x == loaded_rg.grid_x
-    assert original_rg.grid_y == loaded_rg.grid_y
-    # TODO: uncomment when iris mesh comparison becomes available.
-    # assert original_rg.mesh == loaded_rg.mesh
-
-    # Compare the weight matrices.
-    original_matrix = original_rg.regridder.weight_matrix
-    loaded_matrix = loaded_rg.regridder.weight_matrix
-    # Ensure the original and loaded weight matrix have identical type.
-    assert type(original_matrix) is type(loaded_matrix)  # noqa E721
-    assert np.array_equal(original_matrix.todense(), loaded_matrix.todense())
-
-    # Demonstrate regridding still gives the same results.
-    src_data = ma.arange(np.product(src.data.shape)).reshape(src.data.shape)
-    src_data[0, 0] = ma.masked
-    src.data = src_data
-    # TODO: make this a cube comparison when mesh comparison becomes available.
-    original_result = original_rg(src).data
-    loaded_result = loaded_rg(src).data
-    assert np.array_equal(original_result, loaded_result)
-    assert np.array_equal(original_result.mask, loaded_result.mask)
-
-    # Ensure version data is equal.
-    assert original_rg.regridder.esmf_version == loaded_rg.regridder.esmf_version
-    assert (
-        original_rg.regridder.esmf_regrid_version
-        == loaded_rg.regridder.esmf_regrid_version
-    )
 
 
 def test_GridToMeshESMFRegridder_curvilinear_round_trip(tmp_path):
@@ -264,9 +225,10 @@ def test_MeshESMFRegridder_masked_round_trip(tmp_path, rg_maker):
     assert np.array_equal(loaded_rg.tgt_mask, original_rg.tgt_mask)
 
 
-def test_MeshToGridESMFRegridder_round_trip(tmp_path):
+@pytest.mark.parametrize("method", ["conservative", "bilinear", "nearest"])
+def test_MeshToGridESMFRegridder_round_trip(tmp_path, method):
     """Test save/load round tripping for `MeshToGridESMFRegridder`."""
-    original_rg, src = _make_mesh_to_grid_regridder(circular=True)
+    original_rg, src = _make_mesh_to_grid_regridder(method=method, circular=True)
     filename = tmp_path / "regridder.nc"
     save_regridder(original_rg, filename)
     loaded_rg = load_regridder(str(filename))
@@ -302,65 +264,26 @@ def test_MeshToGridESMFRegridder_round_trip(tmp_path):
         == loaded_rg.regridder.esmf_regrid_version
     )
 
-    # Ensure resolution is equal.
-    assert original_rg.resolution == loaded_rg.resolution
-    original_res_rg, _ = _make_mesh_to_grid_regridder(resolution=8)
-    res_filename = tmp_path / "regridder_res.nc"
-    save_regridder(original_res_rg, res_filename)
-    loaded_res_rg = load_regridder(str(res_filename))
-    assert original_res_rg.resolution == loaded_res_rg.resolution
-    assert (
-        original_res_rg.regridder.tgt.resolution
-        == loaded_res_rg.regridder.tgt.resolution
-    )
+    if method == "conservative":
+        # Ensure resolution is equal.
+        assert original_rg.resolution == loaded_rg.resolution
+        original_res_rg, _ = _make_mesh_to_grid_regridder(method=method, resolution=8)
+        res_filename = tmp_path / "regridder_res.nc"
+        save_regridder(original_res_rg, res_filename)
+        loaded_res_rg = load_regridder(str(res_filename))
+        assert original_res_rg.resolution == loaded_res_rg.resolution
+        assert (
+            original_res_rg.regridder.tgt.resolution
+            == loaded_res_rg.regridder.tgt.resolution
+        )
 
     # Ensure grid equality for non-circular coords.
-    original_nc_rg, _ = _make_grid_to_mesh_regridder(circular=False)
+    original_nc_rg, _ = _make_grid_to_mesh_regridder(method=method, circular=False)
     nc_filename = tmp_path / "non_circular_regridder.nc"
     save_regridder(original_nc_rg, nc_filename)
     loaded_nc_rg = load_regridder(str(nc_filename))
     assert original_nc_rg.grid_x == loaded_nc_rg.grid_x
     assert original_nc_rg.grid_y == loaded_nc_rg.grid_y
-
-
-@pytest.mark.parametrize("method", ["bilinear", "nearest"])
-def test_MeshToGridESMFRegridder_other_method_round_trip(tmp_path, method):
-    """Test save/load round tripping for `MeshToGridESMFRegridder`."""
-    original_rg, src = _make_mesh_to_grid_regridder(method=method)
-    filename = tmp_path / "regridder.nc"
-    save_regridder(original_rg, filename)
-    loaded_rg = load_regridder(str(filename))
-
-    assert original_rg.location == loaded_rg.location
-    assert original_rg.method == loaded_rg.method
-    assert original_rg.mdtol == loaded_rg.mdtol
-    assert original_rg.grid_x == loaded_rg.grid_x
-    assert original_rg.grid_y == loaded_rg.grid_y
-    # TODO: uncomment when iris mesh comparison becomes available.
-    # assert original_rg.mesh == loaded_rg.mesh
-
-    # Compare the weight matrices.
-    original_matrix = original_rg.regridder.weight_matrix
-    loaded_matrix = loaded_rg.regridder.weight_matrix
-    # Ensure the original and loaded weight matrix have identical type.
-    assert type(original_matrix) is type(loaded_matrix)  # noqa E721
-    assert np.array_equal(original_matrix.todense(), loaded_matrix.todense())
-
-    # Demonstrate regridding still gives the same results.
-    src_data = ma.arange(np.product(src.data.shape)).reshape(src.data.shape)
-    src_data[0] = ma.masked
-    src.data = src_data
-    original_result = original_rg(src).data
-    loaded_result = loaded_rg(src).data
-    assert np.array_equal(original_result, loaded_result)
-    assert np.array_equal(original_result.mask, loaded_result.mask)
-
-    # Ensure version data is equal.
-    assert original_rg.regridder.esmf_version == loaded_rg.regridder.esmf_version
-    assert (
-        original_rg.regridder.esmf_regrid_version
-        == loaded_rg.regridder.esmf_regrid_version
-    )
 
 
 def test_MeshToGridESMFRegridder_curvilinear_round_trip(tmp_path):

--- a/esmf_regrid/tests/unit/experimental/io/test_round_tripping.py
+++ b/esmf_regrid/tests/unit/experimental/io/test_round_tripping.py
@@ -177,50 +177,10 @@ def test_GridToMeshESMFRegridder_round_trip(tmp_path):
     assert original_nc_rg.grid_y == loaded_nc_rg.grid_y
 
 
-def test_GridToMeshESMFRegridder_bilinear_round_trip(tmp_path):
+@pytest.mark.parametrize("method", ["bilinear", "nearest"])
+def test_GridToMeshESMFRegridder_bilinear_round_trip(tmp_path, method):
     """Test save/load round tripping for `GridToMeshESMFRegridder`."""
-    original_rg, src = _make_grid_to_mesh_regridder(method="bilinear")
-    filename = tmp_path / "regridder.nc"
-    save_regridder(original_rg, filename)
-    loaded_rg = load_regridder(str(filename))
-
-    assert original_rg.location == loaded_rg.location
-    assert original_rg.method == loaded_rg.method
-    assert original_rg.mdtol == loaded_rg.mdtol
-    assert original_rg.grid_x == loaded_rg.grid_x
-    assert original_rg.grid_y == loaded_rg.grid_y
-    # TODO: uncomment when iris mesh comparison becomes available.
-    # assert original_rg.mesh == loaded_rg.mesh
-
-    # Compare the weight matrices.
-    original_matrix = original_rg.regridder.weight_matrix
-    loaded_matrix = loaded_rg.regridder.weight_matrix
-    # Ensure the original and loaded weight matrix have identical type.
-    assert type(original_matrix) is type(loaded_matrix)  # noqa E721
-    assert np.array_equal(original_matrix.todense(), loaded_matrix.todense())
-
-    # Demonstrate regridding still gives the same results.
-    src_data = ma.arange(np.product(src.data.shape)).reshape(src.data.shape)
-    src_data[0, 0] = ma.masked
-    src.data = src_data
-    # TODO: make this a cube comparison when mesh comparison becomes available.
-    original_result = original_rg(src).data
-    loaded_result = loaded_rg(src).data
-    assert np.array_equal(original_result, loaded_result)
-    assert np.array_equal(original_result.mask, loaded_result.mask)
-
-    # Ensure version data is equal.
-    assert original_rg.regridder.esmf_version == loaded_rg.regridder.esmf_version
-    assert (
-        original_rg.regridder.esmf_regrid_version
-        == loaded_rg.regridder.esmf_regrid_version
-    )
-
-
-def test_GridToMeshESMFRegridder_nearest_round_trip(tmp_path):
-    """Test save/load round tripping for `GridToMeshESMFRegridder`."""
-    # TODO: refactor as a single parameterised test.
-    original_rg, src = _make_grid_to_mesh_regridder(method="nearest")
+    original_rg, src = _make_grid_to_mesh_regridder(method=method)
     filename = tmp_path / "regridder.nc"
     save_regridder(original_rg, filename)
     loaded_rg = load_regridder(str(filename))
@@ -363,49 +323,10 @@ def test_MeshToGridESMFRegridder_round_trip(tmp_path):
     assert original_nc_rg.grid_y == loaded_nc_rg.grid_y
 
 
-def test_MeshToGridESMFRegridder_bilinear_round_trip(tmp_path):
+@pytest.mark.parametrize("method", ["bilinear", "nearest"])
+def test_MeshToGridESMFRegridder_other_method_round_trip(tmp_path, method):
     """Test save/load round tripping for `MeshToGridESMFRegridder`."""
-    original_rg, src = _make_mesh_to_grid_regridder(method="bilinear")
-    filename = tmp_path / "regridder.nc"
-    save_regridder(original_rg, filename)
-    loaded_rg = load_regridder(str(filename))
-
-    assert original_rg.location == loaded_rg.location
-    assert original_rg.method == loaded_rg.method
-    assert original_rg.mdtol == loaded_rg.mdtol
-    assert original_rg.grid_x == loaded_rg.grid_x
-    assert original_rg.grid_y == loaded_rg.grid_y
-    # TODO: uncomment when iris mesh comparison becomes available.
-    # assert original_rg.mesh == loaded_rg.mesh
-
-    # Compare the weight matrices.
-    original_matrix = original_rg.regridder.weight_matrix
-    loaded_matrix = loaded_rg.regridder.weight_matrix
-    # Ensure the original and loaded weight matrix have identical type.
-    assert type(original_matrix) is type(loaded_matrix)  # noqa E721
-    assert np.array_equal(original_matrix.todense(), loaded_matrix.todense())
-
-    # Demonstrate regridding still gives the same results.
-    src_data = ma.arange(np.product(src.data.shape)).reshape(src.data.shape)
-    src_data[0] = ma.masked
-    src.data = src_data
-    original_result = original_rg(src).data
-    loaded_result = loaded_rg(src).data
-    assert np.array_equal(original_result, loaded_result)
-    assert np.array_equal(original_result.mask, loaded_result.mask)
-
-    # Ensure version data is equal.
-    assert original_rg.regridder.esmf_version == loaded_rg.regridder.esmf_version
-    assert (
-        original_rg.regridder.esmf_regrid_version
-        == loaded_rg.regridder.esmf_regrid_version
-    )
-
-
-def test_MeshToGridESMFRegridder_nearest_round_trip(tmp_path):
-    """Test save/load round tripping for `MeshToGridESMFRegridder`."""
-    # TODO: refactor as a single parameterised test.
-    original_rg, src = _make_mesh_to_grid_regridder(method="nearest")
+    original_rg, src = _make_mesh_to_grid_regridder(method=method)
     filename = tmp_path / "regridder.nc"
     save_regridder(original_rg, filename)
     loaded_rg = load_regridder(str(filename))

--- a/esmf_regrid/tests/unit/experimental/io/test_round_tripping.py
+++ b/esmf_regrid/tests/unit/experimental/io/test_round_tripping.py
@@ -217,6 +217,47 @@ def test_GridToMeshESMFRegridder_bilinear_round_trip(tmp_path):
     )
 
 
+def test_GridToMeshESMFRegridder_nearest_round_trip(tmp_path):
+    """Test save/load round tripping for `GridToMeshESMFRegridder`."""
+    # TODO: refactor as a single parameterised test.
+    original_rg, src = _make_grid_to_mesh_regridder(method="nearest")
+    filename = tmp_path / "regridder.nc"
+    save_regridder(original_rg, filename)
+    loaded_rg = load_regridder(str(filename))
+
+    assert original_rg.location == loaded_rg.location
+    assert original_rg.method == loaded_rg.method
+    assert original_rg.mdtol == loaded_rg.mdtol
+    assert original_rg.grid_x == loaded_rg.grid_x
+    assert original_rg.grid_y == loaded_rg.grid_y
+    # TODO: uncomment when iris mesh comparison becomes available.
+    # assert original_rg.mesh == loaded_rg.mesh
+
+    # Compare the weight matrices.
+    original_matrix = original_rg.regridder.weight_matrix
+    loaded_matrix = loaded_rg.regridder.weight_matrix
+    # Ensure the original and loaded weight matrix have identical type.
+    assert type(original_matrix) is type(loaded_matrix)  # noqa E721
+    assert np.array_equal(original_matrix.todense(), loaded_matrix.todense())
+
+    # Demonstrate regridding still gives the same results.
+    src_data = ma.arange(np.product(src.data.shape)).reshape(src.data.shape)
+    src_data[0, 0] = ma.masked
+    src.data = src_data
+    # TODO: make this a cube comparison when mesh comparison becomes available.
+    original_result = original_rg(src).data
+    loaded_result = loaded_rg(src).data
+    assert np.array_equal(original_result, loaded_result)
+    assert np.array_equal(original_result.mask, loaded_result.mask)
+
+    # Ensure version data is equal.
+    assert original_rg.regridder.esmf_version == loaded_rg.regridder.esmf_version
+    assert (
+        original_rg.regridder.esmf_regrid_version
+        == loaded_rg.regridder.esmf_regrid_version
+    )
+
+
 def test_GridToMeshESMFRegridder_curvilinear_round_trip(tmp_path):
     """Test save/load round tripping for `GridToMeshESMFRegridder`."""
     original_rg, src = _make_grid_to_mesh_regridder(grid_dims=2)
@@ -325,6 +366,46 @@ def test_MeshToGridESMFRegridder_round_trip(tmp_path):
 def test_MeshToGridESMFRegridder_bilinear_round_trip(tmp_path):
     """Test save/load round tripping for `MeshToGridESMFRegridder`."""
     original_rg, src = _make_mesh_to_grid_regridder(method="bilinear")
+    filename = tmp_path / "regridder.nc"
+    save_regridder(original_rg, filename)
+    loaded_rg = load_regridder(str(filename))
+
+    assert original_rg.location == loaded_rg.location
+    assert original_rg.method == loaded_rg.method
+    assert original_rg.mdtol == loaded_rg.mdtol
+    assert original_rg.grid_x == loaded_rg.grid_x
+    assert original_rg.grid_y == loaded_rg.grid_y
+    # TODO: uncomment when iris mesh comparison becomes available.
+    # assert original_rg.mesh == loaded_rg.mesh
+
+    # Compare the weight matrices.
+    original_matrix = original_rg.regridder.weight_matrix
+    loaded_matrix = loaded_rg.regridder.weight_matrix
+    # Ensure the original and loaded weight matrix have identical type.
+    assert type(original_matrix) is type(loaded_matrix)  # noqa E721
+    assert np.array_equal(original_matrix.todense(), loaded_matrix.todense())
+
+    # Demonstrate regridding still gives the same results.
+    src_data = ma.arange(np.product(src.data.shape)).reshape(src.data.shape)
+    src_data[0] = ma.masked
+    src.data = src_data
+    original_result = original_rg(src).data
+    loaded_result = loaded_rg(src).data
+    assert np.array_equal(original_result, loaded_result)
+    assert np.array_equal(original_result.mask, loaded_result.mask)
+
+    # Ensure version data is equal.
+    assert original_rg.regridder.esmf_version == loaded_rg.regridder.esmf_version
+    assert (
+        original_rg.regridder.esmf_regrid_version
+        == loaded_rg.regridder.esmf_regrid_version
+    )
+
+
+def test_MeshToGridESMFRegridder_nearest_round_trip(tmp_path):
+    """Test save/load round tripping for `MeshToGridESMFRegridder`."""
+    # TODO: refactor as a single parameterised test.
+    original_rg, src = _make_mesh_to_grid_regridder(method="nearest")
     filename = tmp_path / "regridder.nc"
     save_regridder(original_rg, filename)
     loaded_rg = load_regridder(str(filename))

--- a/esmf_regrid/tests/unit/experimental/io/test_round_tripping.py
+++ b/esmf_regrid/tests/unit/experimental/io/test_round_tripping.py
@@ -178,7 +178,7 @@ def test_GridToMeshESMFRegridder_round_trip(tmp_path):
 
 
 @pytest.mark.parametrize("method", ["bilinear", "nearest"])
-def test_GridToMeshESMFRegridder_bilinear_round_trip(tmp_path, method):
+def test_GridToMeshESMFRegridder_other_method_round_trip(tmp_path, method):
     """Test save/load round tripping for `GridToMeshESMFRegridder`."""
     original_rg, src = _make_grid_to_mesh_regridder(method=method)
     filename = tmp_path / "regridder.nc"

--- a/esmf_regrid/tests/unit/experimental/unstructured_scheme/test_GridToMeshESMFRegridder.py
+++ b/esmf_regrid/tests/unit/experimental/unstructured_scheme/test_GridToMeshESMFRegridder.py
@@ -1,4 +1,4 @@
-"""Unit tests for :func:`esmf_regrid.experimental.unstructured_scheme.GridToMeshESMFRegridder`."""
+"""Unit tests for :class:`esmf_regrid.experimental.unstructured_scheme.GridToMeshESMFRegridder`."""
 
 import dask.array as da
 from iris.coords import AuxCoord, DimCoord
@@ -37,7 +37,7 @@ def _add_metadata(cube):
 
 def test_flat_cubes():
     """
-    Basic test for :func:`esmf_regrid.experimental.unstructured_scheme.GridToMeshESMFRegridder`.
+    Basic test for :class:`esmf_regrid.experimental.unstructured_scheme.GridToMeshESMFRegridder`.
 
     Tests with flat cubes as input (a 2D grid cube and a 1D mesh cube).
     """
@@ -74,11 +74,12 @@ def test_flat_cubes():
     assert expected_cube == result_transposed
 
 
-def test_bilinear():
+@pytest.mark.parametrize("method", ["bilinear", "nearest"])
+def test_node_friendly_methods(method):
     """
-    Basic test for :func:`esmf_regrid.experimental.unstructured_scheme.GridToMeshESMFRegridder`.
+    Basic test for :class:`esmf_regrid.experimental.unstructured_scheme.GridToMeshESMFRegridder`.
 
-    Tests with method="bilinear".
+    Tests with method="bilinear" and method="nearest".
     """
     n_lons = 6
     n_lats = 5
@@ -90,52 +91,11 @@ def test_bilinear():
 
     src = _add_metadata(src)
     src.data[:] = 1  # Ensure all data in the source is one.
-    face_regridder = GridToMeshESMFRegridder(src, face_tgt, method="bilinear")
-    node_regridder = GridToMeshESMFRegridder(src, node_tgt, method="bilinear")
+    face_regridder = GridToMeshESMFRegridder(src, face_tgt, method=method)
+    node_regridder = GridToMeshESMFRegridder(src, node_tgt, method=method)
 
-    assert face_regridder.regridder.method == "bilinear"
-    assert node_regridder.regridder.method == "bilinear"
-
-    face_expected_data = np.ones_like(face_tgt.data)
-    node_expected_data = np.ones_like(node_tgt.data)
-    face_result = face_regridder(src)
-    node_result = node_regridder(src)
-
-    # Lenient check for data.
-    assert np.allclose(face_expected_data, face_result.data)
-    assert np.allclose(node_expected_data, node_result.data)
-
-    # Check metadata and scalar coords.
-    face_expected_cube = _add_metadata(face_tgt)
-    node_expected_cube = _add_metadata(node_tgt)
-    face_expected_cube.data = face_result.data
-    node_expected_cube.data = node_result.data
-    assert face_expected_cube == face_result
-    assert node_expected_cube == node_result
-
-
-def test_nearest():
-    """
-    Basic test for :func:`esmf_regrid.experimental.unstructured_scheme.GridToMeshESMFRegridder`.
-
-    Tests with method="nearest".
-    """
-    # TODO: refactor this and test_bilinear into a single parameterised test.
-    n_lons = 6
-    n_lats = 5
-    lon_bounds = (-180, 180)
-    lat_bounds = (-90, 90)
-    src = _grid_cube(n_lons, n_lats, lon_bounds, lat_bounds, circular=True)
-    face_tgt = _gridlike_mesh_cube(n_lons, n_lats, location="face")
-    node_tgt = _gridlike_mesh_cube(n_lons, n_lats, location="node")
-
-    src = _add_metadata(src)
-    src.data[:] = 1  # Ensure all data in the source is one.
-    face_regridder = GridToMeshESMFRegridder(src, face_tgt, method="nearest")
-    node_regridder = GridToMeshESMFRegridder(src, node_tgt, method="nearest")
-
-    assert face_regridder.regridder.method == "nearest"
-    assert node_regridder.regridder.method == "nearest"
+    assert face_regridder.regridder.method == method
+    assert node_regridder.regridder.method == method
 
     face_expected_data = np.ones_like(face_tgt.data)
     node_expected_data = np.ones_like(node_tgt.data)
@@ -157,7 +117,7 @@ def test_nearest():
 
 def test_multidim_cubes():
     """
-    Test for :func:`esmf_regrid.experimental.unstructured_scheme.regrid_rectilinear_to_unstructured`.
+    Test for :class:`esmf_regrid.experimental.unstructured_scheme.regrid_rectilinear_to_unstructured`.
 
     Tests with multidimensional cubes. The source cube contains
     coordinates on the dimensions before and after the grid dimensions.
@@ -206,7 +166,7 @@ def test_multidim_cubes():
 
 def test_invalid_mdtol():
     """
-    Test initialisation of :func:`esmf_regrid.experimental.unstructured_scheme.GridToMeshESMFRegridder`.
+    Test initialisation of :class:`esmf_regrid.experimental.unstructured_scheme.GridToMeshESMFRegridder`.
 
     Checks that an error is raised when mdtol is out of range.
     """
@@ -226,7 +186,7 @@ def test_invalid_mdtol():
 
 def test_invalid_method():
     """
-    Test initialisation of :func:`esmf_regrid.experimental.unstructured_scheme.GridToMeshESMFRegridder`.
+    Test initialisation of :class:`esmf_regrid.experimental.unstructured_scheme.GridToMeshESMFRegridder`.
 
     Checks that an error is raised when the method is invalid.
     """
@@ -266,7 +226,7 @@ def test_invalid_method():
 
 def test_invalid_resolution():
     """
-    Test initialisation of :func:`esmf_regrid.experimental.unstructured_scheme.GridToMeshESMFRegridder`.
+    Test initialisation of :class:`esmf_regrid.experimental.unstructured_scheme.GridToMeshESMFRegridder`.
 
     Checks that an error is raised when the resolution is invalid.
     """
@@ -290,7 +250,7 @@ def test_invalid_resolution():
 
 def test_default_mdtol():
     """
-    Test initialisation of :func:`esmf_regrid.experimental.unstructured_scheme.GridToMeshESMFRegridder`.
+    Test initialisation of :class:`esmf_regrid.experimental.unstructured_scheme.GridToMeshESMFRegridder`.
 
     Checks that default mdtol values are as expected.
     """
@@ -309,7 +269,7 @@ def test_default_mdtol():
 
 def test_mismatched_grids():
     """
-    Test error handling in calling of :func:`esmf_regrid.experimental.unstructured_scheme.GridToMeshESMFRegridder`.
+    Test error handling in calling of :class:`esmf_regrid.experimental.unstructured_scheme.GridToMeshESMFRegridder`.
 
     Checks that an error is raised when the regridder is called with a
     cube whose grid does not match with the one used when initialising
@@ -335,7 +295,7 @@ def test_mismatched_grids():
 
 def test_mask_handling():
     """
-    Test masked data handling for :func:`esmf_regrid.experimental.unstructured_scheme.GridToMeshESMFRegridder`.
+    Test masked data handling for :class:`esmf_regrid.experimental.unstructured_scheme.GridToMeshESMFRegridder`.
 
     Tests masked data handling for multiple valid values for mdtol.
     """
@@ -405,7 +365,7 @@ def test_laziness():
 
 def test_resolution():
     """
-    Test for :func:`esmf_regrid.experimental.unstructured_scheme.GridToMeshESMFRegridder`.
+    Test for :class:`esmf_regrid.experimental.unstructured_scheme.GridToMeshESMFRegridder`.
 
     Tests for the src_resolution keyword.
     """
@@ -425,7 +385,7 @@ def test_resolution():
 
 def test_curvilinear():
     """
-    Test for :func:`esmf_regrid.experimental.unstructured_scheme.regrid_rectilinear_to_unstructured`.
+    Test for :class:`esmf_regrid.experimental.unstructured_scheme.regrid_rectilinear_to_unstructured`.
 
     Tests with curvilinear target cube.
     """
@@ -479,7 +439,7 @@ def test_curvilinear():
 )
 def test_masks(resolution):
     """
-    Test initialisation of :func:`esmf_regrid.experimental.unstructured_scheme.GridToMeshESMFRegridder`.
+    Test initialisation of :class:`esmf_regrid.experimental.unstructured_scheme.GridToMeshESMFRegridder`.
 
     Checks that the `use_src_mask` and `use_tgt_mask` keywords work properly.
     """

--- a/esmf_regrid/tests/unit/experimental/unstructured_scheme/test_MeshToGridESMFRegridder.py
+++ b/esmf_regrid/tests/unit/experimental/unstructured_scheme/test_MeshToGridESMFRegridder.py
@@ -1,4 +1,4 @@
-"""Unit tests for :func:`esmf_regrid.experimental.unstructured_scheme.MeshToGridESMFRegridder`."""
+"""Unit tests for :class:`esmf_regrid.experimental.unstructured_scheme.MeshToGridESMFRegridder`."""
 
 import dask.array as da
 from iris.coords import AuxCoord, DimCoord
@@ -37,7 +37,7 @@ def _add_metadata(cube):
 
 def test_flat_cubes():
     """
-    Basic test for :func:`esmf_regrid.experimental.unstructured_scheme.MeshToGridESMFRegridder`.
+    Basic test for :class:`esmf_regrid.experimental.unstructured_scheme.MeshToGridESMFRegridder`.
 
     Tests with flat cubes as input (a 1D mesh cube and a 2D grid cube).
     """
@@ -68,11 +68,12 @@ def test_flat_cubes():
     assert expected_cube == result
 
 
-def test_bilinear():
+@pytest.mark.parametrize("method", ["bilinear", "nearest"])
+def test_node_friendly_methods(method):
     """
-    Basic test for :func:`esmf_regrid.experimental.unstructured_scheme.MeshToGridESMFRegridder`.
+    Basic test for :class:`esmf_regrid.experimental.unstructured_scheme.MeshToGridESMFRegridder`.
 
-    Tests with method="bilinear".
+    Tests with method="bilinear" and method="nearest".
     """
     n_lons = 6
     n_lats = 5
@@ -87,51 +88,11 @@ def test_bilinear():
     # Ensure all data in the source is one.
     face_src.data[:] = 1
     node_src.data[:] = 1
-    face_regridder = MeshToGridESMFRegridder(face_src, tgt, method="bilinear")
-    node_regridder = MeshToGridESMFRegridder(node_src, tgt, method="bilinear")
+    face_regridder = MeshToGridESMFRegridder(face_src, tgt, method=method)
+    node_regridder = MeshToGridESMFRegridder(node_src, tgt, method=method)
 
-    assert face_regridder.regridder.method == "bilinear"
-    assert node_regridder.regridder.method == "bilinear"
-
-    expected_data = np.ones_like(tgt.data)
-    face_result = face_regridder(face_src)
-    node_result = node_regridder(node_src)
-
-    # Lenient check for data.
-    assert np.allclose(expected_data, face_result.data)
-    assert np.allclose(expected_data, node_result.data)
-
-    # Check metadata and scalar coords.
-    expected_cube = _add_metadata(tgt)
-    expected_cube.data = face_result.data = node_result.data
-    assert expected_cube == face_result == node_result
-
-
-def test_nearest():
-    """
-    Basic test for :func:`esmf_regrid.experimental.unstructured_scheme.MeshToGridESMFRegridder`.
-
-    Tests with method="nearest".
-    """
-    # TODO: refactor this and test_bilinear into a single parameterised test.
-    n_lons = 6
-    n_lats = 5
-    lon_bounds = (-180, 180)
-    lat_bounds = (-90, 90)
-    tgt = _grid_cube(n_lons, n_lats, lon_bounds, lat_bounds, circular=True)
-    face_src = _gridlike_mesh_cube(n_lons, n_lats, location="face")
-    node_src = _gridlike_mesh_cube(n_lons, n_lats, location="node")
-
-    face_src = _add_metadata(face_src)
-    node_src = _add_metadata(node_src)
-    # Ensure all data in the source is one.
-    face_src.data[:] = 1
-    node_src.data[:] = 1
-    face_regridder = MeshToGridESMFRegridder(face_src, tgt, method="nearest")
-    node_regridder = MeshToGridESMFRegridder(node_src, tgt, method="nearest")
-
-    assert face_regridder.regridder.method == "nearest"
-    assert node_regridder.regridder.method == "nearest"
+    assert face_regridder.regridder.method == method
+    assert node_regridder.regridder.method == method
 
     expected_data = np.ones_like(tgt.data)
     face_result = face_regridder(face_src)
@@ -149,7 +110,7 @@ def test_nearest():
 
 def test_multidim_cubes():
     """
-    Test for :func:`esmf_regrid.experimental.unstructured_scheme.MeshToGridESMFRegridder`.
+    Test for :class:`esmf_regrid.experimental.unstructured_scheme.MeshToGridESMFRegridder`.
 
     Tests with multidimensional cubes. The source cube contains
     coordinates on the dimensions before and after the mesh dimension.
@@ -200,7 +161,7 @@ def test_multidim_cubes():
 
 def test_invalid_mdtol():
     """
-    Test initialisation of :func:`esmf_regrid.experimental.unstructured_scheme.MeshToGridESMFRegridder`.
+    Test initialisation of :class:`esmf_regrid.experimental.unstructured_scheme.MeshToGridESMFRegridder`.
 
     Checks that an error is raised when mdtol is out of range.
     """
@@ -220,7 +181,7 @@ def test_invalid_mdtol():
 
 def test_invalid_method():
     """
-    Test initialisation of :func:`esmf_regrid.experimental.unstructured_scheme.MeshToGridESMFRegridder`.
+    Test initialisation of :class:`esmf_regrid.experimental.unstructured_scheme.MeshToGridESMFRegridder`.
 
     Checks that an error is raised when method is invalid.
     """
@@ -260,7 +221,7 @@ def test_invalid_method():
 
 def test_invalid_resolution():
     """
-    Test initialisation of :func:`esmf_regrid.experimental.unstructured_scheme.MeshToGridESMFRegridder`.
+    Test initialisation of :class:`esmf_regrid.experimental.unstructured_scheme.MeshToGridESMFRegridder`.
 
     Checks that an error is raised when the resolution is invalid.
     """
@@ -284,7 +245,7 @@ def test_invalid_resolution():
 
 def test_default_mdtol():
     """
-    Test initialisation of :func:`esmf_regrid.experimental.unstructured_scheme.MeshToGridESMFRegridder`.
+    Test initialisation of :class:`esmf_regrid.experimental.unstructured_scheme.MeshToGridESMFRegridder`.
 
     Checks that default mdtol values are as expected.
     """
@@ -304,7 +265,7 @@ def test_default_mdtol():
 @pytest.mark.xfail
 def test_mistmatched_mesh():
     """
-    Test the calling of :func:`esmf_regrid.experimental.unstructured_scheme.MeshToGridESMFRegridder`.
+    Test the calling of :class:`esmf_regrid.experimental.unstructured_scheme.MeshToGridESMFRegridder`.
 
     Checks that an error is raised when the regridder is called with a cube
     whose mesh does not match the one used for initialisation.
@@ -374,7 +335,7 @@ def test_laziness():
 
 def test_resolution():
     """
-    Test for :func:`esmf_regrid.experimental.unstructured_scheme.MeshToGridESMFRegridder`.
+    Test for :class:`esmf_regrid.experimental.unstructured_scheme.MeshToGridESMFRegridder`.
 
     Tests for the tgt_resolution keyword.
     """
@@ -402,7 +363,7 @@ def test_resolution():
 
 def test_curvilinear():
     """
-    Test for :func:`esmf_regrid.experimental.unstructured_scheme.MeshToGridESMFRegridder`.
+    Test for :class:`esmf_regrid.experimental.unstructured_scheme.MeshToGridESMFRegridder`.
 
     Tests with curvilinear source cube.
     """
@@ -458,7 +419,7 @@ def test_curvilinear():
 )
 def test_masks(resolution):
     """
-    Test initialisation of :func:`esmf_regrid.experimental.unstructured_scheme.MeshToGridESMFRegridder`.
+    Test initialisation of :class:`esmf_regrid.experimental.unstructured_scheme.MeshToGridESMFRegridder`.
 
     Checks that the `use_src_mask` and `use_tgt_mask` keywords work properly.
     """

--- a/esmf_regrid/tests/unit/experimental/unstructured_scheme/test_regrid_rectilinear_to_unstructured.py
+++ b/esmf_regrid/tests/unit/experimental/unstructured_scheme/test_regrid_rectilinear_to_unstructured.py
@@ -71,7 +71,7 @@ def test_flat_cubes():
 
 
 @pytest.mark.parametrize("method", ("bilinear", "nearest"))
-def test_other_methods(method):
+def test_node_friendly_methods(method):
     """
     Basic test for :func:`esmf_regrid.experimental.unstructured_scheme.regrid_rectilinear_to_unstructured`.
 

--- a/esmf_regrid/tests/unit/experimental/unstructured_scheme/test_regrid_rectilinear_to_unstructured.py
+++ b/esmf_regrid/tests/unit/experimental/unstructured_scheme/test_regrid_rectilinear_to_unstructured.py
@@ -70,11 +70,12 @@ def test_flat_cubes():
     assert expected_cube == result_transposed
 
 
-def test_bilinear():
+@pytest.mark.parametrize("method", ("bilinear", "nearest"))
+def test_other_methods(method):
     """
     Basic test for :func:`esmf_regrid.experimental.unstructured_scheme.regrid_rectilinear_to_unstructured`.
 
-    Tests with the bilinear method.
+    Tests with the bilinear and nearest method.
     """
     n_lons = 6
     n_lats = 5
@@ -88,7 +89,7 @@ def test_bilinear():
 
     src = _add_metadata(src)
     src.data[:] = 1  # Ensure all data in the source is one.
-    result = regrid_rectilinear_to_unstructured(src, tgt, method="bilinear")
+    result = regrid_rectilinear_to_unstructured(src, tgt, method=method)
 
     expected_data = np.ones_like(tgt.data)
     expected_cube = _add_metadata(tgt)
@@ -130,7 +131,14 @@ def test_invalid_args():
     with pytest.raises(ValueError) as excinfo:
         _ = regrid_rectilinear_to_unstructured(src, edge_tgt, method="bilinear")
     expected_message = (
-        "Bilinear regridding requires a target cube with a node "
+        "bilinear regridding requires a target cube with a node "
+        "or face location, target cube had the edge location."
+    )
+    assert expected_message in str(excinfo.value)
+    with pytest.raises(ValueError) as excinfo:
+        _ = regrid_rectilinear_to_unstructured(src, edge_tgt, method="nearest")
+    expected_message = (
+        "nearest regridding requires a target cube with a node "
         "or face location, target cube had the edge location."
     )
     assert expected_message in str(excinfo.value)

--- a/esmf_regrid/tests/unit/experimental/unstructured_scheme/test_regrid_unstructured_to_rectilinear.py
+++ b/esmf_regrid/tests/unit/experimental/unstructured_scheme/test_regrid_unstructured_to_rectilinear.py
@@ -64,11 +64,12 @@ def test_flat_cubes():
     assert expected_cube == result
 
 
-def test_bilinear():
+@pytest.mark.parametrize("method", ("bilinear", "nearest"))
+def test_other_methods(method):
     """
     Basic test for :func:`esmf_regrid.experimental.unstructured_scheme.regrid_unstructured_to_rectilinear`.
 
-    Tests with the bilinear method.
+    Tests with the bilinear and nearest method.
     """
     n_lons = 6
     n_lats = 5
@@ -82,7 +83,7 @@ def test_bilinear():
 
     src = _add_metadata(src)
     src.data[:] = 1  # Ensure all data in the source is one.
-    result = regrid_unstructured_to_rectilinear(src, tgt, method="bilinear")
+    result = regrid_unstructured_to_rectilinear(src, tgt, method=method)
 
     expected_data = np.ones([n_lats, n_lons])
     expected_cube = _add_metadata(tgt)
@@ -124,7 +125,14 @@ def test_invalid_args():
     with pytest.raises(ValueError) as excinfo:
         _ = regrid_unstructured_to_rectilinear(edge_src, tgt, method="bilinear")
     expected_message = (
-        "Bilinear regridding requires a source cube with a node "
+        "bilinear regridding requires a source cube with a node "
+        "or face location, target cube had the edge location."
+    )
+    assert expected_message in str(excinfo.value)
+    with pytest.raises(ValueError) as excinfo:
+        _ = regrid_unstructured_to_rectilinear(edge_src, tgt, method="nearest")
+    expected_message = (
+        "nearest regridding requires a source cube with a node "
         "or face location, target cube had the edge location."
     )
     assert expected_message in str(excinfo.value)

--- a/esmf_regrid/tests/unit/experimental/unstructured_scheme/test_regrid_unstructured_to_rectilinear.py
+++ b/esmf_regrid/tests/unit/experimental/unstructured_scheme/test_regrid_unstructured_to_rectilinear.py
@@ -65,7 +65,7 @@ def test_flat_cubes():
 
 
 @pytest.mark.parametrize("method", ("bilinear", "nearest"))
-def test_other_methods(method):
+def test_node_friendly_methods(method):
     """
     Basic test for :func:`esmf_regrid.experimental.unstructured_scheme.regrid_unstructured_to_rectilinear`.
 

--- a/esmf_regrid/tests/unit/schemes/__init__.py
+++ b/esmf_regrid/tests/unit/schemes/__init__.py
@@ -1,1 +1,154 @@
 """Unit tests for `esmf_regrid.schemes`."""
+
+import numpy as np
+from numpy import ma
+import pytest
+
+from esmf_regrid.tests.unit.schemes.test__cube_to_GridInfo import _grid_cube
+from esmf_regrid.tests.unit.schemes.test__mesh_to_MeshInfo import (
+    _gridlike_mesh_cube,
+)
+
+
+def _test_cube_regrid(scheme, src_type, tgt_type):
+    """
+    Test that `scheme` can be passed to a cubes regrid method.
+
+    Checks that regridding occurs and that mdtol is used correctly.
+    """
+    scheme_default = scheme()
+    scheme_full_mdtol = scheme(mdtol=1)
+
+    n_lons_src = 6
+    n_lons_tgt = 3
+    n_lats_src = 4
+    n_lats_tgt = 2
+    lon_bounds = (-180, 180)
+    lat_bounds = (-90, 90)
+    if src_type == "grid":
+        src = _grid_cube(n_lons_src, n_lats_src, lon_bounds, lat_bounds, circular=True)
+        src_data = np.zeros([n_lats_src, n_lons_src])
+        src_mask = np.zeros([n_lats_src, n_lons_src])
+        src_mask[0, 0] = 1
+    else:
+        src = _gridlike_mesh_cube(n_lons_src, n_lats_src)
+        src_data = np.zeros([n_lats_src * n_lons_src])
+        src_mask = np.zeros([n_lats_src * n_lons_src])
+        src_mask[0] = 1
+    if tgt_type == "grid":
+        tgt = _grid_cube(n_lons_tgt, n_lats_tgt, lon_bounds, lat_bounds, circular=True)
+        expected_data_default = np.zeros([n_lats_tgt, n_lons_tgt])
+        expected_mask = np.zeros([n_lats_tgt, n_lons_tgt])
+        expected_mask[0, 0] = 1
+    else:
+        tgt = _gridlike_mesh_cube(n_lons_tgt, n_lats_tgt)
+        expected_data_default = np.zeros([n_lats_tgt * n_lons_tgt])
+        expected_mask = np.zeros([n_lats_tgt * n_lons_tgt])
+        expected_mask[0] = 1
+    src_data = ma.array(src_data, mask=src_mask)
+    src.data = src_data
+
+    result_default = src.regrid(tgt, scheme_default)
+    result_full = src.regrid(tgt, scheme_full_mdtol)
+
+    expected_data_full = ma.array(expected_data_default, mask=expected_mask)
+
+    expected_cube_default = tgt.copy()
+    expected_cube_default.data = expected_data_default
+
+    expected_cube_full = tgt.copy()
+    expected_cube_full.data = expected_data_full
+
+    assert expected_cube_default == result_default
+    assert expected_cube_full == result_full
+
+
+def _test_invalid_mdtol(scheme):
+    """
+    Test initialisation of the scheme.
+
+    Checks that an error is raised when mdtol is out of range.
+    """
+    match = "Value for mdtol must be in range 0 - 1, got "
+    with pytest.raises(ValueError, match=match):
+        _ = scheme(mdtol=2)
+    with pytest.raises(ValueError, match=match):
+        _ = scheme(mdtol=-1)
+
+
+def _test_mask_from_init(scheme, mask_keyword):
+    """
+    Test initialisation of scheme.
+
+    Checks that use_src_mask and use_tgt_mask are passed down correctly.
+    """
+    # Create a scheme with and without masking behaviour
+    kwargs = {mask_keyword: True}
+    default_scheme = scheme()
+    masked_scheme = scheme(**kwargs)
+    assert getattr(default_scheme, mask_keyword) is False
+    assert getattr(masked_scheme, mask_keyword) is True
+
+    n_lons_src = 6
+    n_lats_src = 4
+    lon_bounds = (-180, 180)
+    lat_bounds = (-90, 90)
+    cube = _grid_cube(n_lons_src, n_lats_src, lon_bounds, lat_bounds, circular=True)
+    data = np.zeros([n_lats_src, n_lons_src])
+    mask = np.zeros([n_lats_src, n_lons_src])
+    mask[0, 0] = 1
+    data = ma.array(data, mask=mask)
+    cube.data = data
+
+    # Create a regridder from the scheme.
+    default_rg = default_scheme.regridder(cube, cube)
+    masked_rg = masked_scheme.regridder(cube, cube)
+
+    # Remove "use_" from the keyword to get the equivalent attr used on the regridder.
+    regridder_attr = mask_keyword[4:]
+
+    # Check that the mask stored on the regridder is correct.
+    assert getattr(default_rg, regridder_attr) is None
+    np.testing.assert_allclose(getattr(masked_rg, regridder_attr), mask)
+
+
+def _test_mask_from_regridder(scheme, mask_keyword):
+    """
+    Test regridder method of the scheme.
+
+    Checks that use_src_mask and use_tgt_mask are passed down correctly.
+    """
+    n_lons_src = 6
+    n_lats_src = 4
+    lon_bounds = (-180, 180)
+    lat_bounds = (-90, 90)
+    cube = _grid_cube(n_lons_src, n_lats_src, lon_bounds, lat_bounds, circular=True)
+    data = np.zeros([n_lats_src, n_lons_src])
+    mask = np.zeros([n_lats_src, n_lons_src])
+    mask[0, 0] = 1
+    data = ma.array(data, mask=mask)
+    cube.data = data
+
+    mask_different = np.zeros([n_lats_src, n_lons_src])
+    mask_different[1, 2] = 1
+
+    # Create a scheme without default masking behaviour.
+    default_scheme = scheme()
+
+    # Create a regridder from the mask on the cube.
+    kwargs = {mask_keyword: True}
+    rg_from_cube = default_scheme.regridder(cube, cube, **kwargs)
+
+    # Create a regridder from a user supplied mask.
+    kwargs_different = {mask_keyword: mask_different}
+    rg_from_different = default_scheme.regridder(cube, cube, **kwargs_different)
+
+    # Remove "use_" from the keyword to get the equivalent attr used on the regridder.
+    regridder_attr = mask_keyword[4:]
+
+    # Check that the mask stored on the regridder is correct.
+    np.testing.assert_allclose(getattr(rg_from_cube, regridder_attr), mask)
+    np.testing.assert_allclose(
+        getattr(rg_from_different, regridder_attr), mask_different
+    )
+

--- a/esmf_regrid/tests/unit/schemes/test_ESMFAreaWeighted.py
+++ b/esmf_regrid/tests/unit/schemes/test_ESMFAreaWeighted.py
@@ -1,4 +1,4 @@
-"""Unit tests for :func:`esmf_regrid.schemes.ESMFAreaWeighted`."""
+"""Unit tests for :class:`esmf_regrid.schemes.ESMFAreaWeighted`."""
 
 import pytest
 
@@ -25,7 +25,7 @@ def test_cube_regrid(src_type, tgt_type):
 
 def test_invalid_mdtol():
     """
-    Test initialisation of :func:`esmf_regrid.schemes.ESMFAreaWeighted`.
+    Test initialisation of :class:`esmf_regrid.schemes.ESMFAreaWeighted`.
 
     Checks that an error is raised when mdtol is out of range.
     """
@@ -35,7 +35,7 @@ def test_invalid_mdtol():
 @pytest.mark.parametrize("mask_keyword", ["use_src_mask", "use_tgt_mask"])
 def test_mask_from_init(mask_keyword):
     """
-    Test initialisation of :func:`esmf_regrid.schemes.ESMFAreaWeighted`.
+    Test initialisation of :class:`esmf_regrid.schemes.ESMFAreaWeighted`.
 
     Checks that use_src_mask and use_tgt_mask are passed down correctly.
     """
@@ -45,7 +45,7 @@ def test_mask_from_init(mask_keyword):
 @pytest.mark.parametrize("mask_keyword", ["use_src_mask", "use_tgt_mask"])
 def test_mask_from_regridder(mask_keyword):
     """
-    Test regridder method of :func:`esmf_regrid.schemes.ESMFAreaWeighted`.
+    Test regridder method of :class:`esmf_regrid.schemes.ESMFAreaWeighted`.
 
     Checks that use_src_mask and use_tgt_mask are passed down correctly.
     """

--- a/esmf_regrid/tests/unit/schemes/test_ESMFAreaWeighted.py
+++ b/esmf_regrid/tests/unit/schemes/test_ESMFAreaWeighted.py
@@ -91,8 +91,8 @@ def test_mask_from_init(mask_keyword):
     kwargs = {mask_keyword: True}
     default_scheme = ESMFAreaWeighted()
     masked_scheme = ESMFAreaWeighted(**kwargs)
-    assert getattr(default_scheme, mask_keyword) == False
-    assert getattr(masked_scheme, mask_keyword) == True
+    assert getattr(default_scheme, mask_keyword) is False
+    assert getattr(masked_scheme, mask_keyword) is True
 
     n_lons_src = 6
     n_lats_src = 4

--- a/esmf_regrid/tests/unit/schemes/test_ESMFAreaWeighted.py
+++ b/esmf_regrid/tests/unit/schemes/test_ESMFAreaWeighted.py
@@ -78,3 +78,82 @@ def test_invalid_mdtol():
         _ = ESMFAreaWeighted(mdtol=2)
     with pytest.raises(ValueError, match=match):
         _ = ESMFAreaWeighted(mdtol=-1)
+
+
+@pytest.mark.parametrize("mask_keyword", ["use_src_mask", "use_tgt_mask"])
+def test_mask_from_init(mask_keyword):
+    """
+    Test initialisation of :func:`esmf_regrid.schemes.ESMFAreaWeighted`.
+
+    Checks that use_src_mask and use_tgt_mask are passed down correctly.
+    """
+    # Create a scheme with and without masking behaviour
+    kwargs = {mask_keyword: True}
+    default_scheme = ESMFAreaWeighted()
+    masked_scheme = ESMFAreaWeighted(**kwargs)
+    assert getattr(default_scheme, mask_keyword) == False
+    assert getattr(masked_scheme, mask_keyword) == True
+
+    n_lons_src = 6
+    n_lats_src = 4
+    lon_bounds = (-180, 180)
+    lat_bounds = (-90, 90)
+    cube = _grid_cube(n_lons_src, n_lats_src, lon_bounds, lat_bounds, circular=True)
+    data = np.zeros([n_lats_src, n_lons_src])
+    mask = np.zeros([n_lats_src, n_lons_src])
+    mask[0, 0] = 1
+    data = ma.array(data, mask=mask)
+    cube.data = data
+
+    # Create a regridder from the scheme.
+    default_rg = default_scheme.regridder(cube, cube)
+    masked_rg = masked_scheme.regridder(cube, cube)
+
+    # Remove "use_" from the keyword to get the equivalent attr used on the regridder.
+    regridder_attr = mask_keyword[4:]
+
+    # Check that the mask stored on the regridder is correct.
+    assert getattr(default_rg, regridder_attr) is None
+    np.testing.assert_allclose(getattr(masked_rg, regridder_attr), mask)
+
+
+@pytest.mark.parametrize("mask_keyword", ["use_src_mask", "use_tgt_mask"])
+def test_mask_from_regridder(mask_keyword):
+    """
+    Test regridder method of :func:`esmf_regrid.schemes.ESMFAreaWeighted`.
+
+    Checks that use_src_mask and use_tgt_mask are passed down correctly.
+    """
+    n_lons_src = 6
+    n_lats_src = 4
+    lon_bounds = (-180, 180)
+    lat_bounds = (-90, 90)
+    cube = _grid_cube(n_lons_src, n_lats_src, lon_bounds, lat_bounds, circular=True)
+    data = np.zeros([n_lats_src, n_lons_src])
+    mask = np.zeros([n_lats_src, n_lons_src])
+    mask[0, 0] = 1
+    data = ma.array(data, mask=mask)
+    cube.data = data
+
+    mask_different = np.zeros([n_lats_src, n_lons_src])
+    mask_different[1, 2] = 1
+
+    # Create a scheme without default masking behaviour.
+    default_scheme = ESMFAreaWeighted()
+
+    # Create a regridder from the mask on the cube.
+    kwargs = {mask_keyword: True}
+    rg_from_cube = default_scheme.regridder(cube, cube, **kwargs)
+
+    # Create a regridder from a user supplied mask.
+    kwargs_different = {mask_keyword: mask_different}
+    rg_from_different = default_scheme.regridder(cube, cube, **kwargs_different)
+
+    # Remove "use_" from the keyword to get the equivalent attr used on the regridder.
+    regridder_attr = mask_keyword[4:]
+
+    # Check that the mask stored on the regridder is correct.
+    np.testing.assert_allclose(getattr(rg_from_cube, regridder_attr), mask)
+    np.testing.assert_allclose(
+        getattr(rg_from_different, regridder_attr), mask_different
+    )

--- a/esmf_regrid/tests/unit/schemes/test_ESMFAreaWeighted.py
+++ b/esmf_regrid/tests/unit/schemes/test_ESMFAreaWeighted.py
@@ -1,13 +1,13 @@
 """Unit tests for :func:`esmf_regrid.schemes.ESMFAreaWeighted`."""
 
-import numpy as np
-from numpy import ma
 import pytest
 
 from esmf_regrid.schemes import ESMFAreaWeighted
-from esmf_regrid.tests.unit.schemes.test__cube_to_GridInfo import _grid_cube
-from esmf_regrid.tests.unit.schemes.test__mesh_to_MeshInfo import (
-    _gridlike_mesh_cube,
+from esmf_regrid.tests.unit.schemes.__init__ import (
+    _test_cube_regrid,
+    _test_invalid_mdtol,
+    _test_mask_from_init,
+    _test_mask_from_regridder,
 )
 
 
@@ -20,51 +20,7 @@ def test_cube_regrid(src_type, tgt_type):
 
     Checks that regridding occurs and that mdtol is used correctly.
     """
-    scheme_default = ESMFAreaWeighted()
-    scheme_full_mdtol = ESMFAreaWeighted(mdtol=1)
-
-    n_lons_src = 6
-    n_lons_tgt = 3
-    n_lats_src = 4
-    n_lats_tgt = 2
-    lon_bounds = (-180, 180)
-    lat_bounds = (-90, 90)
-    if src_type == "grid":
-        src = _grid_cube(n_lons_src, n_lats_src, lon_bounds, lat_bounds, circular=True)
-        src_data = np.zeros([n_lats_src, n_lons_src])
-        src_mask = np.zeros([n_lats_src, n_lons_src])
-        src_mask[0, 0] = 1
-    else:
-        src = _gridlike_mesh_cube(n_lons_src, n_lats_src)
-        src_data = np.zeros([n_lats_src * n_lons_src])
-        src_mask = np.zeros([n_lats_src * n_lons_src])
-        src_mask[0] = 1
-    if tgt_type == "grid":
-        tgt = _grid_cube(n_lons_tgt, n_lats_tgt, lon_bounds, lat_bounds, circular=True)
-        expected_data_default = np.zeros([n_lats_tgt, n_lons_tgt])
-        expected_mask = np.zeros([n_lats_tgt, n_lons_tgt])
-        expected_mask[0, 0] = 1
-    else:
-        tgt = _gridlike_mesh_cube(n_lons_tgt, n_lats_tgt)
-        expected_data_default = np.zeros([n_lats_tgt * n_lons_tgt])
-        expected_mask = np.zeros([n_lats_tgt * n_lons_tgt])
-        expected_mask[0] = 1
-    src_data = ma.array(src_data, mask=src_mask)
-    src.data = src_data
-
-    result_default = src.regrid(tgt, scheme_default)
-    result_full = src.regrid(tgt, scheme_full_mdtol)
-
-    expected_data_full = ma.array(expected_data_default, mask=expected_mask)
-
-    expected_cube_default = tgt.copy()
-    expected_cube_default.data = expected_data_default
-
-    expected_cube_full = tgt.copy()
-    expected_cube_full.data = expected_data_full
-
-    assert expected_cube_default == result_default
-    assert expected_cube_full == result_full
+    _test_cube_regrid(ESMFAreaWeighted, src_type, tgt_type)
 
 
 def test_invalid_mdtol():
@@ -73,11 +29,7 @@ def test_invalid_mdtol():
 
     Checks that an error is raised when mdtol is out of range.
     """
-    match = "Value for mdtol must be in range 0 - 1, got "
-    with pytest.raises(ValueError, match=match):
-        _ = ESMFAreaWeighted(mdtol=2)
-    with pytest.raises(ValueError, match=match):
-        _ = ESMFAreaWeighted(mdtol=-1)
+    _test_invalid_mdtol(ESMFAreaWeighted)
 
 
 @pytest.mark.parametrize("mask_keyword", ["use_src_mask", "use_tgt_mask"])
@@ -87,34 +39,7 @@ def test_mask_from_init(mask_keyword):
 
     Checks that use_src_mask and use_tgt_mask are passed down correctly.
     """
-    # Create a scheme with and without masking behaviour
-    kwargs = {mask_keyword: True}
-    default_scheme = ESMFAreaWeighted()
-    masked_scheme = ESMFAreaWeighted(**kwargs)
-    assert getattr(default_scheme, mask_keyword) is False
-    assert getattr(masked_scheme, mask_keyword) is True
-
-    n_lons_src = 6
-    n_lats_src = 4
-    lon_bounds = (-180, 180)
-    lat_bounds = (-90, 90)
-    cube = _grid_cube(n_lons_src, n_lats_src, lon_bounds, lat_bounds, circular=True)
-    data = np.zeros([n_lats_src, n_lons_src])
-    mask = np.zeros([n_lats_src, n_lons_src])
-    mask[0, 0] = 1
-    data = ma.array(data, mask=mask)
-    cube.data = data
-
-    # Create a regridder from the scheme.
-    default_rg = default_scheme.regridder(cube, cube)
-    masked_rg = masked_scheme.regridder(cube, cube)
-
-    # Remove "use_" from the keyword to get the equivalent attr used on the regridder.
-    regridder_attr = mask_keyword[4:]
-
-    # Check that the mask stored on the regridder is correct.
-    assert getattr(default_rg, regridder_attr) is None
-    np.testing.assert_allclose(getattr(masked_rg, regridder_attr), mask)
+    _test_mask_from_init(ESMFAreaWeighted, mask_keyword)
 
 
 @pytest.mark.parametrize("mask_keyword", ["use_src_mask", "use_tgt_mask"])
@@ -124,36 +49,4 @@ def test_mask_from_regridder(mask_keyword):
 
     Checks that use_src_mask and use_tgt_mask are passed down correctly.
     """
-    n_lons_src = 6
-    n_lats_src = 4
-    lon_bounds = (-180, 180)
-    lat_bounds = (-90, 90)
-    cube = _grid_cube(n_lons_src, n_lats_src, lon_bounds, lat_bounds, circular=True)
-    data = np.zeros([n_lats_src, n_lons_src])
-    mask = np.zeros([n_lats_src, n_lons_src])
-    mask[0, 0] = 1
-    data = ma.array(data, mask=mask)
-    cube.data = data
-
-    mask_different = np.zeros([n_lats_src, n_lons_src])
-    mask_different[1, 2] = 1
-
-    # Create a scheme without default masking behaviour.
-    default_scheme = ESMFAreaWeighted()
-
-    # Create a regridder from the mask on the cube.
-    kwargs = {mask_keyword: True}
-    rg_from_cube = default_scheme.regridder(cube, cube, **kwargs)
-
-    # Create a regridder from a user supplied mask.
-    kwargs_different = {mask_keyword: mask_different}
-    rg_from_different = default_scheme.regridder(cube, cube, **kwargs_different)
-
-    # Remove "use_" from the keyword to get the equivalent attr used on the regridder.
-    regridder_attr = mask_keyword[4:]
-
-    # Check that the mask stored on the regridder is correct.
-    np.testing.assert_allclose(getattr(rg_from_cube, regridder_attr), mask)
-    np.testing.assert_allclose(
-        getattr(rg_from_different, regridder_attr), mask_different
-    )
+    _test_mask_from_regridder(ESMFAreaWeighted, mask_keyword)

--- a/esmf_regrid/tests/unit/schemes/test_ESMFAreaWeightedRegridder.py
+++ b/esmf_regrid/tests/unit/schemes/test_ESMFAreaWeightedRegridder.py
@@ -1,4 +1,4 @@
-"""Unit tests for :func:`esmf_regrid.schemes.ESMFAreaWeightedRegridder`."""
+"""Unit tests for :class:`esmf_regrid.schemes.ESMFAreaWeightedRegridder`."""
 
 from cf_units import Unit
 import numpy as np
@@ -13,7 +13,7 @@ from esmf_regrid.tests.unit.schemes.test__cube_to_GridInfo import (
 
 def test_dim_switching():
     """
-    Test calling of :func:`esmf_regrid.schemes.ESMFAreaWeightedRegridder`.
+    Test calling of :class:`esmf_regrid.schemes.ESMFAreaWeightedRegridder`.
 
     Checks that the regridder accepts a cube with dimensions in a different
     order than the cube which initialised it. Checks that dimension order is
@@ -41,7 +41,7 @@ def test_dim_switching():
 
 def test_differing_grids():
     """
-    Test calling of :func:`esmf_regrid.schemes.ESMFAreaWeightedRegridder`.
+    Test calling of :class:`esmf_regrid.schemes.ESMFAreaWeightedRegridder`.
 
     Checks that the regridder raises an error when given a cube with a different
     grid to the one it was initialised with.
@@ -70,7 +70,7 @@ def test_differing_grids():
 
 def test_invalid_mdtol():
     """
-    Test initialisation of :func:`esmf_regrid.schemes.ESMFAreaWeightedRegridder`.
+    Test initialisation of :class:`esmf_regrid.schemes.ESMFAreaWeightedRegridder`.
 
     Checks that an error is raised when mdtol is out of range.
     """
@@ -90,7 +90,7 @@ def test_invalid_mdtol():
 
 def test_curvilinear_equivalence():
     """
-    Test initialisation of :func:`esmf_regrid.schemes.ESMFAreaWeightedRegridder`.
+    Test initialisation of :class:`esmf_regrid.schemes.ESMFAreaWeightedRegridder`.
 
     Checks that equivalent curvilinear and rectilinear coordinates give the same
     results.
@@ -120,7 +120,7 @@ def test_curvilinear_equivalence():
 
 def test_curvilinear_and_rectilinear():
     """
-    Test :func:`esmf_regrid.schemes.ESMFAreaWeightedRegridder`.
+    Test :class:`esmf_regrid.schemes.ESMFAreaWeightedRegridder`.
 
     Checks that a cube with both curvilinear and rectilinear coords still works.
     Checks that the DimCoords have priority over AuxCoords.
@@ -173,7 +173,7 @@ def test_curvilinear_and_rectilinear():
 
 def test_unit_equivalence():
     """
-    Test initialisation of :func:`esmf_regrid.schemes.ESMFAreaWeightedRegridder`.
+    Test initialisation of :class:`esmf_regrid.schemes.ESMFAreaWeightedRegridder`.
 
     Checks that equivalent coordinates in degrees and radians give the same results.
     """
@@ -233,7 +233,7 @@ def test_unit_equivalence():
 
 def test_masks():
     """
-    Test initialisation of :func:`esmf_regrid.schemes.ESMFAreaWeightedRegridder`.
+    Test initialisation of :class:`esmf_regrid.schemes.ESMFAreaWeightedRegridder`.
 
     Checks that the `use_src_mask` and `use_tgt_mask` keywords work properly.
     """

--- a/esmf_regrid/tests/unit/schemes/test_ESMFBilinear.py
+++ b/esmf_regrid/tests/unit/schemes/test_ESMFBilinear.py
@@ -78,3 +78,83 @@ def test_invalid_mdtol():
         _ = ESMFBilinear(mdtol=2)
     with pytest.raises(ValueError, match=match):
         _ = ESMFBilinear(mdtol=-1)
+
+
+@pytest.mark.parametrize("mask_keyword", ["use_src_mask", "use_tgt_mask"])
+def test_mask_from_init(mask_keyword):
+    """
+    Test initialisation of :func:`esmf_regrid.schemes.ESMFBilinear`.
+
+    Checks that use_src_mask and use_tgt_mask are passed down correctly.
+    """
+    # Create a scheme with and without masking behaviour
+    kwargs = {mask_keyword: True}
+    default_scheme = ESMFBilinear()
+    masked_scheme = ESMFBilinear(**kwargs)
+    assert getattr(default_scheme, mask_keyword) == False
+    assert getattr(masked_scheme, mask_keyword) == True
+
+    n_lons_src = 6
+    n_lats_src = 4
+    lon_bounds = (-180, 180)
+    lat_bounds = (-90, 90)
+    cube = _grid_cube(n_lons_src, n_lats_src, lon_bounds, lat_bounds, circular=True)
+    data = np.zeros([n_lats_src, n_lons_src])
+    mask = np.zeros([n_lats_src, n_lons_src])
+    mask[0, 0] = 1
+    data = ma.array(data, mask=mask)
+    cube.data = data
+
+    # Create a regridder from the scheme.
+    default_rg = default_scheme.regridder(cube, cube)
+    masked_rg = masked_scheme.regridder(cube, cube)
+
+    # Remove "use_" from the keyword to get the equivalent attr used on the regridder.
+    regridder_attr = mask_keyword[4:]
+
+    # Check that the mask stored on the regridder is correct.
+    assert getattr(default_rg, regridder_attr) is None
+    np.testing.assert_allclose(getattr(masked_rg, regridder_attr), mask)
+
+
+@pytest.mark.parametrize("mask_keyword", ["use_src_mask", "use_tgt_mask"])
+def test_mask_from_regridder(mask_keyword):
+    """
+    Test regridder method of :func:`esmf_regrid.schemes.ESMFBilinear`.
+
+    Checks that use_src_mask and use_tgt_mask are passed down correctly.
+    """
+    n_lons_src = 6
+    n_lats_src = 4
+    lon_bounds = (-180, 180)
+    lat_bounds = (-90, 90)
+    cube = _grid_cube(n_lons_src, n_lats_src, lon_bounds, lat_bounds, circular=True)
+    data = np.zeros([n_lats_src, n_lons_src])
+    mask = np.zeros([n_lats_src, n_lons_src])
+    mask[0, 0] = 1
+    data = ma.array(data, mask=mask)
+    cube.data = data
+
+    mask_different = np.zeros([n_lats_src, n_lons_src])
+    mask_different[1, 2] = 1
+
+    # Create a scheme without default masking behaviour.
+    default_scheme = ESMFBilinear()
+
+    # Create a regridder from the mask on the cube.
+    kwargs = {mask_keyword: True}
+    rg_from_cube = default_scheme.regridder(cube, cube, **kwargs)
+
+    # Create a regridder from a user supplied mask.
+    kwargs_different = {mask_keyword: mask_different}
+    rg_from_different = default_scheme.regridder(cube, cube, **kwargs_different)
+
+    # Remove "use_" from the keyword to get the equivalent attr used on the regridder.
+    regridder_attr = mask_keyword[4:]
+
+    # Check that the mask stored on the regridder is correct.
+    np.testing.assert_allclose(getattr(rg_from_cube, regridder_attr), mask)
+    np.testing.assert_allclose(
+        getattr(rg_from_different, regridder_attr), mask_different
+    )
+

--- a/esmf_regrid/tests/unit/schemes/test_ESMFBilinear.py
+++ b/esmf_regrid/tests/unit/schemes/test_ESMFBilinear.py
@@ -1,4 +1,4 @@
-"""Unit tests for :func:`esmf_regrid.schemes.ESMFBilinear`."""
+"""Unit tests for :class:`esmf_regrid.schemes.ESMFBilinear`."""
 
 import pytest
 
@@ -25,7 +25,7 @@ def test_cube_regrid(src_type, tgt_type):
 
 def test_invalid_mdtol():
     """
-    Test initialisation of :func:`esmf_regrid.schemes.ESMFBilinear`.
+    Test initialisation of :class:`esmf_regrid.schemes.ESMFBilinear`.
 
     Checks that an error is raised when mdtol is out of range.
     """
@@ -35,7 +35,7 @@ def test_invalid_mdtol():
 @pytest.mark.parametrize("mask_keyword", ["use_src_mask", "use_tgt_mask"])
 def test_mask_from_init(mask_keyword):
     """
-    Test initialisation of :func:`esmf_regrid.schemes.ESMFBilinear`.
+    Test initialisation of :class:`esmf_regrid.schemes.ESMFBilinear`.
 
     Checks that use_src_mask and use_tgt_mask are passed down correctly.
     """
@@ -45,7 +45,7 @@ def test_mask_from_init(mask_keyword):
 @pytest.mark.parametrize("mask_keyword", ["use_src_mask", "use_tgt_mask"])
 def test_mask_from_regridder(mask_keyword):
     """
-    Test regridder method of :func:`esmf_regrid.schemes.ESMFBilinear`.
+    Test regridder method of :class:`esmf_regrid.schemes.ESMFBilinear`.
 
     Checks that use_src_mask and use_tgt_mask are passed down correctly.
     """

--- a/esmf_regrid/tests/unit/schemes/test_ESMFBilinear.py
+++ b/esmf_regrid/tests/unit/schemes/test_ESMFBilinear.py
@@ -157,4 +157,3 @@ def test_mask_from_regridder(mask_keyword):
     np.testing.assert_allclose(
         getattr(rg_from_different, regridder_attr), mask_different
     )
-

--- a/esmf_regrid/tests/unit/schemes/test_ESMFBilinear.py
+++ b/esmf_regrid/tests/unit/schemes/test_ESMFBilinear.py
@@ -91,8 +91,8 @@ def test_mask_from_init(mask_keyword):
     kwargs = {mask_keyword: True}
     default_scheme = ESMFBilinear()
     masked_scheme = ESMFBilinear(**kwargs)
-    assert getattr(default_scheme, mask_keyword) == False
-    assert getattr(masked_scheme, mask_keyword) == True
+    assert getattr(default_scheme, mask_keyword) is False
+    assert getattr(masked_scheme, mask_keyword) is True
 
     n_lons_src = 6
     n_lats_src = 4

--- a/esmf_regrid/tests/unit/schemes/test_ESMFBilinear.py
+++ b/esmf_regrid/tests/unit/schemes/test_ESMFBilinear.py
@@ -1,13 +1,13 @@
 """Unit tests for :func:`esmf_regrid.schemes.ESMFBilinear`."""
 
-import numpy as np
-from numpy import ma
 import pytest
 
 from esmf_regrid.schemes import ESMFBilinear
-from esmf_regrid.tests.unit.schemes.test__cube_to_GridInfo import _grid_cube
-from esmf_regrid.tests.unit.schemes.test__mesh_to_MeshInfo import (
-    _gridlike_mesh_cube,
+from esmf_regrid.tests.unit.schemes.__init__ import (
+    _test_cube_regrid,
+    _test_invalid_mdtol,
+    _test_mask_from_init,
+    _test_mask_from_regridder,
 )
 
 
@@ -20,51 +20,7 @@ def test_cube_regrid(src_type, tgt_type):
 
     Checks that regridding occurs and that mdtol is used correctly.
     """
-    scheme_default = ESMFBilinear()
-    scheme_full_mdtol = ESMFBilinear(mdtol=1)
-
-    n_lons_src = 6
-    n_lons_tgt = 3
-    n_lats_src = 4
-    n_lats_tgt = 2
-    lon_bounds = (-180, 180)
-    lat_bounds = (-90, 90)
-    if src_type == "grid":
-        src = _grid_cube(n_lons_src, n_lats_src, lon_bounds, lat_bounds, circular=True)
-        src_data = np.zeros([n_lats_src, n_lons_src])
-        src_mask = np.zeros([n_lats_src, n_lons_src])
-        src_mask[0, 0] = 1
-    else:
-        src = _gridlike_mesh_cube(n_lons_src, n_lats_src)
-        src_data = np.zeros([n_lats_src * n_lons_src])
-        src_mask = np.zeros([n_lats_src * n_lons_src])
-        src_mask[0] = 1
-    if tgt_type == "grid":
-        tgt = _grid_cube(n_lons_tgt, n_lats_tgt, lon_bounds, lat_bounds, circular=True)
-        expected_data_default = np.zeros([n_lats_tgt, n_lons_tgt])
-        expected_mask = np.zeros([n_lats_tgt, n_lons_tgt])
-        expected_mask[0, 0] = 1
-    else:
-        tgt = _gridlike_mesh_cube(n_lons_tgt, n_lats_tgt)
-        expected_data_default = np.zeros([n_lats_tgt * n_lons_tgt])
-        expected_mask = np.zeros([n_lats_tgt * n_lons_tgt])
-        expected_mask[0] = 1
-    src_data = ma.array(src_data, mask=src_mask)
-    src.data = src_data
-
-    result_default = src.regrid(tgt, scheme_default)
-    result_full = src.regrid(tgt, scheme_full_mdtol)
-
-    expected_data_full = ma.array(expected_data_default, mask=expected_mask)
-
-    expected_cube_default = tgt.copy()
-    expected_cube_default.data = expected_data_default
-
-    expected_cube_full = tgt.copy()
-    expected_cube_full.data = expected_data_full
-
-    assert expected_cube_default == result_default
-    assert expected_cube_full == result_full
+    _test_cube_regrid(ESMFBilinear, src_type, tgt_type)
 
 
 def test_invalid_mdtol():
@@ -73,11 +29,7 @@ def test_invalid_mdtol():
 
     Checks that an error is raised when mdtol is out of range.
     """
-    match = "Value for mdtol must be in range 0 - 1, got "
-    with pytest.raises(ValueError, match=match):
-        _ = ESMFBilinear(mdtol=2)
-    with pytest.raises(ValueError, match=match):
-        _ = ESMFBilinear(mdtol=-1)
+    _test_invalid_mdtol(ESMFBilinear)
 
 
 @pytest.mark.parametrize("mask_keyword", ["use_src_mask", "use_tgt_mask"])
@@ -87,34 +39,7 @@ def test_mask_from_init(mask_keyword):
 
     Checks that use_src_mask and use_tgt_mask are passed down correctly.
     """
-    # Create a scheme with and without masking behaviour
-    kwargs = {mask_keyword: True}
-    default_scheme = ESMFBilinear()
-    masked_scheme = ESMFBilinear(**kwargs)
-    assert getattr(default_scheme, mask_keyword) is False
-    assert getattr(masked_scheme, mask_keyword) is True
-
-    n_lons_src = 6
-    n_lats_src = 4
-    lon_bounds = (-180, 180)
-    lat_bounds = (-90, 90)
-    cube = _grid_cube(n_lons_src, n_lats_src, lon_bounds, lat_bounds, circular=True)
-    data = np.zeros([n_lats_src, n_lons_src])
-    mask = np.zeros([n_lats_src, n_lons_src])
-    mask[0, 0] = 1
-    data = ma.array(data, mask=mask)
-    cube.data = data
-
-    # Create a regridder from the scheme.
-    default_rg = default_scheme.regridder(cube, cube)
-    masked_rg = masked_scheme.regridder(cube, cube)
-
-    # Remove "use_" from the keyword to get the equivalent attr used on the regridder.
-    regridder_attr = mask_keyword[4:]
-
-    # Check that the mask stored on the regridder is correct.
-    assert getattr(default_rg, regridder_attr) is None
-    np.testing.assert_allclose(getattr(masked_rg, regridder_attr), mask)
+    _test_mask_from_init(ESMFBilinear, mask_keyword)
 
 
 @pytest.mark.parametrize("mask_keyword", ["use_src_mask", "use_tgt_mask"])
@@ -124,36 +49,4 @@ def test_mask_from_regridder(mask_keyword):
 
     Checks that use_src_mask and use_tgt_mask are passed down correctly.
     """
-    n_lons_src = 6
-    n_lats_src = 4
-    lon_bounds = (-180, 180)
-    lat_bounds = (-90, 90)
-    cube = _grid_cube(n_lons_src, n_lats_src, lon_bounds, lat_bounds, circular=True)
-    data = np.zeros([n_lats_src, n_lons_src])
-    mask = np.zeros([n_lats_src, n_lons_src])
-    mask[0, 0] = 1
-    data = ma.array(data, mask=mask)
-    cube.data = data
-
-    mask_different = np.zeros([n_lats_src, n_lons_src])
-    mask_different[1, 2] = 1
-
-    # Create a scheme without default masking behaviour.
-    default_scheme = ESMFBilinear()
-
-    # Create a regridder from the mask on the cube.
-    kwargs = {mask_keyword: True}
-    rg_from_cube = default_scheme.regridder(cube, cube, **kwargs)
-
-    # Create a regridder from a user supplied mask.
-    kwargs_different = {mask_keyword: mask_different}
-    rg_from_different = default_scheme.regridder(cube, cube, **kwargs_different)
-
-    # Remove "use_" from the keyword to get the equivalent attr used on the regridder.
-    regridder_attr = mask_keyword[4:]
-
-    # Check that the mask stored on the regridder is correct.
-    np.testing.assert_allclose(getattr(rg_from_cube, regridder_attr), mask)
-    np.testing.assert_allclose(
-        getattr(rg_from_different, regridder_attr), mask_different
-    )
+    _test_mask_from_regridder(ESMFBilinear, mask_keyword)

--- a/esmf_regrid/tests/unit/schemes/test_ESMFBilinearRegridder.py
+++ b/esmf_regrid/tests/unit/schemes/test_ESMFBilinearRegridder.py
@@ -1,4 +1,4 @@
-"""Unit tests for :func:`esmf_regrid.schemes.ESMFBilinearRegridder`."""
+"""Unit tests for :class:`esmf_regrid.schemes.ESMFBilinearRegridder`."""
 
 from cf_units import Unit
 import numpy as np
@@ -13,7 +13,7 @@ from esmf_regrid.tests.unit.schemes.test__cube_to_GridInfo import (
 
 def test_dim_switching():
     """
-    Test calling of :func:`esmf_regrid.schemes.ESMFBilinearRegridder`.
+    Test calling of :class:`esmf_regrid.schemes.ESMFBilinearRegridder`.
 
     Checks that the regridder accepts a cube with dimensions in a different
     order than the cube which initialised it. Checks that dimension order is
@@ -41,7 +41,7 @@ def test_dim_switching():
 
 def test_differing_grids():
     """
-    Test calling of :func:`esmf_regrid.schemes.ESMFBilinearRegridder`.
+    Test calling of :class:`esmf_regrid.schemes.ESMFBilinearRegridder`.
 
     Checks that the regridder raises an error when given a cube with a different
     grid to the one it was initialised with.
@@ -70,7 +70,7 @@ def test_differing_grids():
 
 def test_invalid_mdtol():
     """
-    Test initialisation of :func:`esmf_regrid.schemes.ESMFBilinearRegridder`.
+    Test initialisation of :class:`esmf_regrid.schemes.ESMFBilinearRegridder`.
 
     Checks that an error is raised when mdtol is out of range.
     """
@@ -90,7 +90,7 @@ def test_invalid_mdtol():
 
 def test_curvilinear_equivalence():
     """
-    Test initialisation of :func:`esmf_regrid.schemes.ESMFBilinearRegridder`.
+    Test initialisation of :class:`esmf_regrid.schemes.ESMFBilinearRegridder`.
 
     Checks that equivalent curvilinear and rectilinear coordinates give the same
     results.
@@ -120,7 +120,7 @@ def test_curvilinear_equivalence():
 
 def test_curvilinear_and_rectilinear():
     """
-    Test :func:`esmf_regrid.schemes.ESMFBilinearRegridder`.
+    Test :class:`esmf_regrid.schemes.ESMFBilinearRegridder`.
 
     Checks that a cube with both curvilinear and rectilinear coords still works.
     Checks that the DimCoords have priority over AuxCoords.
@@ -173,7 +173,7 @@ def test_curvilinear_and_rectilinear():
 
 def test_unit_equivalence():
     """
-    Test initialisation of :func:`esmf_regrid.schemes.ESMFBilinearRegridder`.
+    Test initialisation of :class:`esmf_regrid.schemes.ESMFBilinearRegridder`.
 
     Checks that equivalent coordinates in degrees and radians give the same results.
     """
@@ -233,7 +233,7 @@ def test_unit_equivalence():
 
 def test_masks():
     """
-    Test initialisation of :func:`esmf_regrid.schemes.ESMFBilinearRegridder`.
+    Test initialisation of :class:`esmf_regrid.schemes.ESMFBilinearRegridder`.
 
     Checks that the `use_src_mask` and `use_tgt_mask` keywords work properly.
     """
@@ -274,7 +274,7 @@ def test_masks():
 
 def test_regrid_data():
     """
-    Test initialisation of :func:`esmf_regrid.schemes.ESMFBilinearRegridder`.
+    Test initialisation of :class:`esmf_regrid.schemes.ESMFBilinearRegridder`.
 
     Checks that regridding mathematics behaves in an expected way.
     """

--- a/esmf_regrid/tests/unit/schemes/test_ESMFNearest.py
+++ b/esmf_regrid/tests/unit/schemes/test_ESMFNearest.py
@@ -70,8 +70,8 @@ def test_mask_from_init(mask_keyword):
     kwargs = {mask_keyword: True}
     default_scheme = ESMFNearest()
     masked_scheme = ESMFNearest(**kwargs)
-    assert getattr(default_scheme, mask_keyword) == False
-    assert getattr(masked_scheme, mask_keyword) == True
+    assert getattr(default_scheme, mask_keyword) is False
+    assert getattr(masked_scheme, mask_keyword) is True
 
     n_lons_src = 6
     n_lats_src = 4

--- a/esmf_regrid/tests/unit/schemes/test_ESMFNearest.py
+++ b/esmf_regrid/tests/unit/schemes/test_ESMFNearest.py
@@ -6,12 +6,12 @@ import pytest
 
 from esmf_regrid.schemes import ESMFNearest
 from esmf_regrid.tests.unit.schemes.test__cube_to_GridInfo import _grid_cube
-from esmf_regrid.tests.unit.schemes.test__mesh_to_MeshInfo import (
-    _gridlike_mesh_cube,
-)
 from esmf_regrid.tests.unit.schemes.__init__ import (
     _test_mask_from_init,
     _test_mask_from_regridder,
+)
+from esmf_regrid.tests.unit.schemes.test__mesh_to_MeshInfo import (
+    _gridlike_mesh_cube,
 )
 
 

--- a/esmf_regrid/tests/unit/schemes/test_ESMFNearest.py
+++ b/esmf_regrid/tests/unit/schemes/test_ESMFNearest.py
@@ -1,0 +1,59 @@
+"""Unit tests for :func:`esmf_regrid.schemes.ESMFNearest`."""
+
+import numpy as np
+from numpy import ma
+import pytest
+
+from esmf_regrid.schemes import ESMFNearest
+from esmf_regrid.tests.unit.schemes.test__cube_to_GridInfo import _grid_cube
+from esmf_regrid.tests.unit.schemes.test__mesh_to_MeshInfo import (
+    _gridlike_mesh_cube,
+)
+
+
+@pytest.mark.parametrize(
+    "src_type,tgt_type", [("grid", "grid"), ("grid", "mesh"), ("mesh", "grid")]
+)
+def test_cube_regrid(src_type, tgt_type):
+    """
+    Test that ESMFNearest can be passed to a cubes regrid method.
+
+    Checks that regridding occurs.
+    """
+    scheme_default = ESMFNearest()
+
+    n_lons_src = 6
+    n_lons_tgt = 3
+    n_lats_src = 4
+    n_lats_tgt = 2
+    lon_bounds = (-180, 180)
+    lat_bounds = (-90, 90)
+    if src_type == "grid":
+        src = _grid_cube(n_lons_src, n_lats_src, lon_bounds, lat_bounds, circular=True)
+        src_data = np.zeros([n_lats_src, n_lons_src])
+        src_mask = np.zeros([n_lats_src, n_lons_src])
+        src_mask[0, 0] = 1
+    else:
+        src = _gridlike_mesh_cube(n_lons_src, n_lats_src)
+        src_data = np.zeros([n_lats_src * n_lons_src])
+        src_mask = np.zeros([n_lats_src * n_lons_src])
+        src_mask[0] = 1
+    if tgt_type == "grid":
+        tgt = _grid_cube(n_lons_tgt, n_lats_tgt, lon_bounds, lat_bounds, circular=True)
+        expected_data_default = np.zeros([n_lats_tgt, n_lons_tgt])
+        expected_mask = np.zeros([n_lats_tgt, n_lons_tgt])
+        expected_mask[0, 0] = 1
+    else:
+        tgt = _gridlike_mesh_cube(n_lons_tgt, n_lats_tgt)
+        expected_data_default = np.zeros([n_lats_tgt * n_lons_tgt])
+        expected_mask = np.zeros([n_lats_tgt * n_lons_tgt])
+        expected_mask[0] = 1
+    src_data = ma.array(src_data, mask=src_mask)
+    src.data = src_data
+
+    result_default = src.regrid(tgt, scheme_default)
+
+    expected_cube_default = tgt.copy()
+    expected_cube_default.data = expected_data_default
+
+    assert expected_cube_default == result_default

--- a/esmf_regrid/tests/unit/schemes/test_ESMFNearest.py
+++ b/esmf_regrid/tests/unit/schemes/test_ESMFNearest.py
@@ -1,15 +1,15 @@
-"""Unit tests for :func:`esmf_regrid.schemes.ESMFNearest`."""
+"""Unit tests for :class:`esmf_regrid.schemes.ESMFNearest`."""
 
 import numpy as np
 from numpy import ma
 import pytest
 
 from esmf_regrid.schemes import ESMFNearest
-from esmf_regrid.tests.unit.schemes.test__cube_to_GridInfo import _grid_cube
 from esmf_regrid.tests.unit.schemes.__init__ import (
     _test_mask_from_init,
     _test_mask_from_regridder,
 )
+from esmf_regrid.tests.unit.schemes.test__cube_to_GridInfo import _grid_cube
 from esmf_regrid.tests.unit.schemes.test__mesh_to_MeshInfo import (
     _gridlike_mesh_cube,
 )
@@ -66,7 +66,7 @@ def test_cube_regrid(src_type, tgt_type):
 @pytest.mark.parametrize("mask_keyword", ["use_src_mask", "use_tgt_mask"])
 def test_mask_from_init(mask_keyword):
     """
-    Test initialisation of :func:`esmf_regrid.schemes.ESMFNearest`.
+    Test initialisation of :class:`esmf_regrid.schemes.ESMFNearest`.
 
     Checks that use_src_mask and use_tgt_mask are passed down correctly.
     """
@@ -76,7 +76,7 @@ def test_mask_from_init(mask_keyword):
 @pytest.mark.parametrize("mask_keyword", ["use_src_mask", "use_tgt_mask"])
 def test_mask_from_regridder(mask_keyword):
     """
-    Test regridder method of :func:`esmf_regrid.schemes.ESMFNearest`.
+    Test regridder method of :class:`esmf_regrid.schemes.ESMFNearest`.
 
     Checks that use_src_mask and use_tgt_mask are passed down correctly.
     """

--- a/esmf_regrid/tests/unit/schemes/test_ESMFNearest.py
+++ b/esmf_regrid/tests/unit/schemes/test_ESMFNearest.py
@@ -9,6 +9,10 @@ from esmf_regrid.tests.unit.schemes.test__cube_to_GridInfo import _grid_cube
 from esmf_regrid.tests.unit.schemes.test__mesh_to_MeshInfo import (
     _gridlike_mesh_cube,
 )
+from esmf_regrid.tests.unit.schemes.__init__ import (
+    _test_mask_from_init,
+    _test_mask_from_regridder,
+)
 
 
 @pytest.mark.parametrize(
@@ -66,34 +70,7 @@ def test_mask_from_init(mask_keyword):
 
     Checks that use_src_mask and use_tgt_mask are passed down correctly.
     """
-    # Create a scheme with and without masking behaviour
-    kwargs = {mask_keyword: True}
-    default_scheme = ESMFNearest()
-    masked_scheme = ESMFNearest(**kwargs)
-    assert getattr(default_scheme, mask_keyword) is False
-    assert getattr(masked_scheme, mask_keyword) is True
-
-    n_lons_src = 6
-    n_lats_src = 4
-    lon_bounds = (-180, 180)
-    lat_bounds = (-90, 90)
-    cube = _grid_cube(n_lons_src, n_lats_src, lon_bounds, lat_bounds, circular=True)
-    data = np.zeros([n_lats_src, n_lons_src])
-    mask = np.zeros([n_lats_src, n_lons_src])
-    mask[0, 0] = 1
-    data = ma.array(data, mask=mask)
-    cube.data = data
-
-    # Create a regridder from the scheme.
-    default_rg = default_scheme.regridder(cube, cube)
-    masked_rg = masked_scheme.regridder(cube, cube)
-
-    # Remove "use_" from the keyword to get the equivalent attr used on the regridder.
-    regridder_attr = mask_keyword[4:]
-
-    # Check that the mask stored on the regridder is correct.
-    assert getattr(default_rg, regridder_attr) is None
-    np.testing.assert_allclose(getattr(masked_rg, regridder_attr), mask)
+    _test_mask_from_init(ESMFNearest, mask_keyword)
 
 
 @pytest.mark.parametrize("mask_keyword", ["use_src_mask", "use_tgt_mask"])
@@ -103,36 +80,4 @@ def test_mask_from_regridder(mask_keyword):
 
     Checks that use_src_mask and use_tgt_mask are passed down correctly.
     """
-    n_lons_src = 6
-    n_lats_src = 4
-    lon_bounds = (-180, 180)
-    lat_bounds = (-90, 90)
-    cube = _grid_cube(n_lons_src, n_lats_src, lon_bounds, lat_bounds, circular=True)
-    data = np.zeros([n_lats_src, n_lons_src])
-    mask = np.zeros([n_lats_src, n_lons_src])
-    mask[0, 0] = 1
-    data = ma.array(data, mask=mask)
-    cube.data = data
-
-    mask_different = np.zeros([n_lats_src, n_lons_src])
-    mask_different[1, 2] = 1
-
-    # Create a scheme without default masking behaviour.
-    default_scheme = ESMFNearest()
-
-    # Create a regridder from the mask on the cube.
-    kwargs = {mask_keyword: True}
-    rg_from_cube = default_scheme.regridder(cube, cube, **kwargs)
-
-    # Create a regridder from a user supplied mask.
-    kwargs_different = {mask_keyword: mask_different}
-    rg_from_different = default_scheme.regridder(cube, cube, **kwargs_different)
-
-    # Remove "use_" from the keyword to get the equivalent attr used on the regridder.
-    regridder_attr = mask_keyword[4:]
-
-    # Check that the mask stored on the regridder is correct.
-    np.testing.assert_allclose(getattr(rg_from_cube, regridder_attr), mask)
-    np.testing.assert_allclose(
-        getattr(rg_from_different, regridder_attr), mask_different
-    )
+    _test_mask_from_regridder(ESMFNearest, mask_keyword)

--- a/esmf_regrid/tests/unit/schemes/test_ESMFNearest.py
+++ b/esmf_regrid/tests/unit/schemes/test_ESMFNearest.py
@@ -136,4 +136,3 @@ def test_mask_from_regridder(mask_keyword):
     np.testing.assert_allclose(
         getattr(rg_from_different, regridder_attr), mask_different
     )
-

--- a/esmf_regrid/tests/unit/schemes/test_ESMFNearestRegridder.py
+++ b/esmf_regrid/tests/unit/schemes/test_ESMFNearestRegridder.py
@@ -160,22 +160,6 @@ def test_unit_equivalence():
 
     Checks that equivalent coordinates in degrees and radians give the same results.
     """
-    # TODO: After I wrote this comment i found out it was kind of wrong, but theres
-    #  still good stuff here. Salvage this into some kind of docstring.
-    # While this test has been copied from test_ESMFBilinerRegridder.py, a slight
-    # change has been made to the parameter n_lons_src.
-    # It should be noted that before this change this test was failing.
-    # This is due to the fact that when two source points are equidistant from a
-    # target point, the chosen source point is dependent on the index which ESMF
-    # gives that point. ESMF describes this decision as arbitrary:
-    # https://earthsystemmodeling.org/docs/release/latest/ESMF_refdoc/node3.html#SECTION03023000000000000000
-    # The indexing iris-esmf-regrid gives can also be seen as somewhat arbitrary
-    # and depends on how the grid is described.
-    # We should expect consistency for the same grid description but not necessarily
-    # for equivalent grids with different descriptions here.
-    # These parameters have been tweaked so that no target point is equidistant from
-    # two nearest source points.
-
     # While this test has been copied from test_ESMFBilinerRegridder.py, a slight
     # change has been made to the parameter n_lons_src.
     # It should be noted that before this change this test was failing.

--- a/esmf_regrid/tests/unit/schemes/test_ESMFNearestRegridder.py
+++ b/esmf_regrid/tests/unit/schemes/test_ESMFNearestRegridder.py
@@ -1,0 +1,334 @@
+"""Unit tests for :func:`esmf_regrid.schemes.ESMFNearestRegridder`."""
+
+from cf_units import Unit
+import numpy as np
+import pytest
+
+from esmf_regrid.schemes import ESMFNearestRegridder
+from esmf_regrid.tests.unit.schemes.test__cube_to_GridInfo import (
+    _curvilinear_cube,
+    _grid_cube,
+)
+from esmf_regrid.tests.unit.schemes.test__mesh_to_MeshInfo import (
+    _gridlike_mesh_cube,
+)
+
+
+def test_dim_switching():
+    """
+    Test calling of :func:`esmf_regrid.schemes.ESMFNearestRegridder`.
+
+    Checks that the regridder accepts a cube with dimensions in a different
+    order than the cube which initialised it. Checks that dimension order is
+    inherited from the cube in the calling function in both cases.
+    """
+    n_lons = 6
+    n_lats = 5
+    lon_bounds = (-180, 180)
+    lat_bounds = (-90, 90)
+    src = _grid_cube(n_lons, n_lats, lon_bounds, lat_bounds, circular=True)
+    tgt = _grid_cube(n_lons, n_lats, lon_bounds, lat_bounds, circular=True)
+
+    regridder = ESMFNearestRegridder(src, tgt)
+    unswitched_result = regridder(src)
+
+    src_switched = src.copy()
+    src_switched.transpose()
+    switched_result = regridder(src_switched)
+
+    assert unswitched_result.coord(dimensions=(0,)).standard_name == "latitude"
+    assert unswitched_result.coord(dimensions=(1,)).standard_name == "longitude"
+    assert switched_result.coord(dimensions=(0,)).standard_name == "longitude"
+    assert switched_result.coord(dimensions=(1,)).standard_name == "latitude"
+
+
+def test_differing_grids():
+    """
+    Test calling of :func:`esmf_regrid.schemes.ESMFNearestRegridder`.
+
+    Checks that the regridder raises an error when given a cube with a different
+    grid to the one it was initialised with.
+    """
+    n_lons = 6
+    n_lats = 5
+    lon_bounds = (-180, 180)
+    lat_bounds = (-90, 90)
+    src_init = _grid_cube(n_lons, n_lats, lon_bounds, lat_bounds, circular=True)
+    tgt = _grid_cube(n_lons, n_lats, lon_bounds, lat_bounds, circular=True)
+
+    n_lons_dif = 7
+    src_dif_coord = _grid_cube(
+        n_lons_dif, n_lats, lon_bounds, lat_bounds, circular=True
+    )
+    src_dif_circ = _grid_cube(n_lons, n_lats, lon_bounds, lat_bounds, circular=False)
+
+    regridder = ESMFNearestRegridder(src_init, tgt)
+
+    msg = "The given cube is not defined on the same source grid as this regridder."
+    with pytest.raises(ValueError, match=msg):
+        _ = regridder(src_dif_coord)
+    with pytest.raises(ValueError, match=msg):
+        _ = regridder(src_dif_circ)
+
+
+def test_curvilinear_equivalence():
+    """
+    Test initialisation of :func:`esmf_regrid.schemes.ESMFNearestRegridder`.
+
+    Checks that equivalent curvilinear and rectilinear coordinates give the same
+    results.
+    """
+    n_lons_src = 6
+    n_lons_tgt = 3
+    n_lats_src = 4
+    n_lats_tgt = 2
+    lon_bounds = (-180, 180)
+    lat_bounds = (-90, 90)
+    grid_src = _grid_cube(n_lons_src, n_lats_src, lon_bounds, lat_bounds, circular=True)
+    grid_tgt = _grid_cube(n_lons_tgt, n_lats_tgt, lon_bounds, lat_bounds, circular=True)
+    curv_src = _curvilinear_cube(n_lons_src, n_lats_src, lon_bounds, lat_bounds)
+    curv_tgt = _curvilinear_cube(n_lons_tgt, n_lats_tgt, lon_bounds, lat_bounds)
+
+    grid_to_grid = ESMFNearestRegridder(grid_src, grid_tgt)
+    grid_to_curv = ESMFNearestRegridder(grid_src, curv_tgt)
+    curv_to_grid = ESMFNearestRegridder(curv_src, grid_tgt)
+    curv_to_curv = ESMFNearestRegridder(curv_src, curv_tgt)
+
+    def extract_weights(regridder):
+        return regridder.regridder.weight_matrix.todense()
+
+    for regridder in [grid_to_curv, curv_to_grid, curv_to_curv]:
+        assert np.allclose(extract_weights(grid_to_grid), extract_weights(regridder))
+
+
+def test_curvilinear_and_rectilinear():
+    """
+    Test :func:`esmf_regrid.schemes.ESMFNearestRegridder`.
+
+    Checks that a cube with both curvilinear and rectilinear coords still works.
+    Checks that the DimCoords have priority over AuxCoords.
+    """
+    n_lons_src = 6
+    n_lons_tgt = 3
+    n_lats_src = 4
+    n_lats_tgt = 2
+    lon_bounds = (-180, 180)
+    lat_bounds = (-90, 90)
+    grid_src = _grid_cube(n_lons_src, n_lats_src, lon_bounds, lat_bounds, circular=True)
+    grid_tgt = _grid_cube(n_lons_tgt, n_lats_tgt, lon_bounds, lat_bounds, circular=True)
+    curv_src = _curvilinear_cube(n_lons_src, n_lats_src, lon_bounds, lat_bounds)
+    curv_tgt = _curvilinear_cube(n_lons_tgt, n_lats_tgt, lon_bounds, lat_bounds)
+
+    src = curv_src.copy()
+    grid_lat_src = grid_src.coord("latitude")
+    grid_lat_src.standard_name = "grid_latitude"
+    src.add_dim_coord(grid_lat_src, 0)
+    grid_lon_src = grid_src.coord("longitude")
+    grid_lon_src.standard_name = "grid_longitude"
+    src.add_dim_coord(grid_lon_src, 1)
+
+    tgt = curv_tgt.copy()
+    grid_lat_tgt = grid_tgt.coord("latitude")
+    grid_lat_tgt.standard_name = "grid_latitude"
+    tgt.add_dim_coord(grid_lat_tgt, 0)
+    grid_lon_tgt = grid_tgt.coord("longitude")
+    grid_lon_tgt.standard_name = "grid_longitude"
+    tgt.add_dim_coord(grid_lon_tgt, 1)
+
+    # Change the AuxCoords to check that the DimCoords have priority.
+    src.coord("latitude").bounds[:] = 0
+    src.coord("longitude").bounds[:] = 0
+    tgt.coord("latitude").bounds[:] = 0
+    tgt.coord("longitude").bounds[:] = 0
+
+    # Ensure the source data is all ones.
+    src.data[:] = 1
+
+    rg = ESMFNearestRegridder(src, tgt)
+    result = rg(src)
+
+    expected = grid_tgt.copy()
+    # If the aux coords had been prioritised, expected.data would be a fully masked array.
+    expected.data[:] = 1
+    assert expected == result
+    assert not np.ma.is_masked(result)
+
+
+def test_unit_equivalence():
+    """
+    Test initialisation of :func:`esmf_regrid.schemes.ESMFNearestRegridder`.
+
+    Checks that equivalent coordinates in degrees and radians give the same results.
+    """
+    # TODO: After I wrote this comment i found out it was kind of wrong, but theres
+    #  still good stuff here. Salvage this into some kind of docstring.
+    # While this test has been copied from test_ESMFBilinerRegridder.py, a slight
+    # change has been made to the parameter n_lons_src.
+    # It should be noted that before this change this test was failing.
+    # This is due to the fact that when two source points are equidistant from a
+    # target point, the chosen source point is dependent on the index which ESMF
+    # gives that point. ESMF describes this decision as arbitrary:
+    # https://earthsystemmodeling.org/docs/release/latest/ESMF_refdoc/node3.html#SECTION03023000000000000000
+    # The indexing iris-esmf-regrid gives can also be seen as somewhat arbitrary
+    # and depends on how the grid is described.
+    # We should expect consistency for the same grid description but not necessarily
+    # for equivalent grids with different descriptions here.
+    # These parameters have been tweaked so that no target point is equidistant from
+    # two nearest source points.
+
+    # While this test has been copied from test_ESMFBilinerRegridder.py, a slight
+    # change has been made to the parameter n_lons_src.
+    # It should be noted that before this change this test was failing.
+    # This is due to the fact that when two source points are equidistant from a
+    # target point, rounding floating point differences due to unit conversion
+    # would have an effect of the result.
+    # These parameters have been tweaked so that no target point is equidistant from
+    # two nearest source points.
+    n_lons_src = 5
+    n_lons_tgt = 3
+    n_lats_src = 4
+    n_lats_tgt = 2
+    lon_bounds = (-180, 180)
+    lat_bounds = (-90, 90)
+    lon_rad_bounds = (-np.pi, np.pi)
+    lat_rad_bounds = (-np.pi / 2, np.pi / 2)
+
+    def rad_coords(cube):
+        cube.coord("latitude").units = Unit("radians")
+        cube.coord("longitude").units = Unit("radians")
+
+    grid_src = _grid_cube(n_lons_src, n_lats_src, lon_bounds, lat_bounds, circular=True)
+    grid_src_rad = _grid_cube(
+        n_lons_src, n_lats_src, lon_rad_bounds, lat_rad_bounds, circular=True
+    )
+    rad_coords(grid_src_rad)
+    grid_tgt = _grid_cube(n_lons_tgt, n_lats_tgt, lon_bounds, lat_bounds, circular=True)
+    grid_tgt_rad = _grid_cube(
+        n_lons_tgt, n_lats_tgt, lon_rad_bounds, lat_rad_bounds, circular=True
+    )
+    rad_coords(grid_tgt_rad)
+    curv_src = _curvilinear_cube(n_lons_src, n_lats_src, lon_bounds, lat_bounds)
+    curv_src_rad = _curvilinear_cube(
+        n_lons_src, n_lats_src, lon_rad_bounds, lat_rad_bounds
+    )
+    rad_coords(curv_src_rad)
+    curv_tgt = _curvilinear_cube(n_lons_tgt, n_lats_tgt, lon_bounds, lat_bounds)
+    curv_tgt_rad = _curvilinear_cube(
+        n_lons_tgt, n_lats_tgt, lon_rad_bounds, lat_rad_bounds
+    )
+    rad_coords(curv_tgt_rad)
+
+    grid_to_grid = ESMFNearestRegridder(grid_src, grid_tgt)
+    grid_rad_to_grid = ESMFNearestRegridder(grid_src_rad, grid_tgt)
+    grid_rad_to_curv = ESMFNearestRegridder(grid_src_rad, curv_tgt)
+    curv_to_grid_rad = ESMFNearestRegridder(curv_src, grid_tgt_rad)
+    curv_rad_to_grid = ESMFNearestRegridder(curv_src_rad, grid_tgt)
+    curv_to_curv_rad = ESMFNearestRegridder(curv_src, curv_tgt_rad)
+
+    def extract_weights(regridder):
+        return regridder.regridder.weight_matrix.todense()
+
+    for regridder in [
+        grid_rad_to_grid,
+        grid_rad_to_curv,
+        curv_to_grid_rad,
+        curv_rad_to_grid,
+        curv_to_curv_rad,
+    ]:
+        assert np.allclose(extract_weights(grid_to_grid), extract_weights(regridder))
+
+
+def test_masks():
+    """
+    Test initialisation of :func:`esmf_regrid.schemes.ESMFNearestRegridder`.
+
+    Checks that the `use_src_mask` and `use_tgt_mask` keywords work properly.
+    """
+    src = _curvilinear_cube(7, 6, [-180, 180], [-90, 90])
+    tgt = _curvilinear_cube(6, 7, [-180, 180], [-90, 90])
+
+    # Make src and tgt discontiguous at (0, 0)
+    src_mask = np.zeros([6, 7], dtype=bool)
+    src_mask[0, 0] = True
+    src.data = np.ma.array(src.data, mask=src_mask)
+    src_discontiguous = src.copy()
+    src_discontiguous.coord("latitude").bounds[0, 0] = 0
+    src_discontiguous.coord("longitude").bounds[0, 0] = 0
+
+    tgt_mask = np.zeros([7, 6], dtype=bool)
+    tgt_mask[0, 0] = True
+    tgt.data = np.ma.array(tgt.data, mask=tgt_mask)
+    tgt_discontiguous = tgt.copy()
+    tgt_discontiguous.coord("latitude").bounds[0, 0] = 0
+    tgt_discontiguous.coord("longitude").bounds[0, 0] = 0
+
+    rg_src_masked = ESMFNearestRegridder(src_discontiguous, tgt, use_src_mask=True)
+    rg_tgt_masked = ESMFNearestRegridder(src, tgt_discontiguous, use_tgt_mask=True)
+    rg_unmasked = ESMFNearestRegridder(src, tgt)
+
+    weights_src_masked = rg_src_masked.regridder.weight_matrix
+    weights_tgt_masked = rg_tgt_masked.regridder.weight_matrix
+    weights_unmasked = rg_unmasked.regridder.weight_matrix
+
+    # Check there are no weights associated with the masked point.
+    assert weights_src_masked[:, 0].nnz == 0
+    assert weights_tgt_masked[0].nnz == 0
+
+    # Check other weights are correct. Note that unique to NEAREST_DTOS, masking a source
+    # point causes the next nearest source point to gain weights in the weight matrix.
+    # because of this, we ignore the row associated with that target point and check
+    # the rest of the weights matrix.
+    assert np.allclose(weights_src_masked[1:].todense(), weights_unmasked[1:].todense())
+    assert np.allclose(weights_tgt_masked[1:].todense(), weights_unmasked[1:].todense())
+
+
+def test_regrid_data():
+    """
+    Test initialisation of :func:`esmf_regrid.schemes.ESMFNearestRegridder`.
+
+    Checks that regridding mathematics behaves in an expected way.
+    """
+    # Create two similar grids so that source data and expected result
+    # data ought to look similar by visual inspection.
+    src = _grid_cube(5, 4, [-180, 180], [-90, 90], circular=True)
+    tgt = _grid_cube(4, 5, [-180, 180], [-90, 90], circular=True)
+
+    src_curv = _curvilinear_cube(5, 4, [-180, 180], [-90, 90])
+    tgt_curv = _curvilinear_cube(4, 5, [-180, 180], [-90, 90])
+
+    src_mesh_cube = _gridlike_mesh_cube(5, 4)
+    tgt_mesh_cube = _gridlike_mesh_cube(4, 5)
+
+    src_data = np.arange(20).reshape([4, 5])
+    src.data = src_data
+    src_curv.data = src_data
+    src_mesh_cube.data = np.arange(20)
+
+    rg = ESMFNearestRegridder(src, tgt)
+    rg_g2m = ESMFNearestRegridder(src, tgt_mesh_cube)
+    rg_m2g = ESMFNearestRegridder(src_mesh_cube, tgt)
+    rg_g2c = ESMFNearestRegridder(src, tgt_curv)
+    rg_c2g = ESMFNearestRegridder(src_curv, tgt)
+
+    # when two source points are equidistant from a
+    # target point, the chosen source point is dependent on the index which ESMF
+    # gives that point. This decision is described by ESMF to be arbitrary, but
+    # ought to be consistent when dealing with the same precise grid.
+    expected_data = np.array(
+        [
+            [0, 1, 3, 4],
+            [5, 6, 8, 9],
+            [5, 6, 8, 9],
+            [10, 11, 13, 14],
+            [15, 16, 18, 19],
+        ]
+    )
+    result = rg(src)
+    result_g2m = rg_g2m(src)
+    result_m2g = rg_m2g(src_mesh_cube)
+    result_g2c = rg_g2c(src)
+    result_c2g = rg_c2g(src_curv)
+
+    for res in [result, result_m2g, result_c2g, result_g2c]:
+        np.testing.assert_allclose(expected_data, res.data)
+    np.testing.assert_allclose(expected_data.flatten(), result_g2m.data)

--- a/esmf_regrid/tests/unit/schemes/test_ESMFNearestRegridder.py
+++ b/esmf_regrid/tests/unit/schemes/test_ESMFNearestRegridder.py
@@ -1,4 +1,4 @@
-"""Unit tests for :func:`esmf_regrid.schemes.ESMFNearestRegridder`."""
+"""Unit tests for :class:`esmf_regrid.schemes.ESMFNearestRegridder`."""
 
 from cf_units import Unit
 import numpy as np
@@ -16,7 +16,7 @@ from esmf_regrid.tests.unit.schemes.test__mesh_to_MeshInfo import (
 
 def test_dim_switching():
     """
-    Test calling of :func:`esmf_regrid.schemes.ESMFNearestRegridder`.
+    Test calling of :class:`esmf_regrid.schemes.ESMFNearestRegridder`.
 
     Checks that the regridder accepts a cube with dimensions in a different
     order than the cube which initialised it. Checks that dimension order is
@@ -44,7 +44,7 @@ def test_dim_switching():
 
 def test_differing_grids():
     """
-    Test calling of :func:`esmf_regrid.schemes.ESMFNearestRegridder`.
+    Test calling of :class:`esmf_regrid.schemes.ESMFNearestRegridder`.
 
     Checks that the regridder raises an error when given a cube with a different
     grid to the one it was initialised with.
@@ -73,7 +73,7 @@ def test_differing_grids():
 
 def test_curvilinear_equivalence():
     """
-    Test initialisation of :func:`esmf_regrid.schemes.ESMFNearestRegridder`.
+    Test initialisation of :class:`esmf_regrid.schemes.ESMFNearestRegridder`.
 
     Checks that equivalent curvilinear and rectilinear coordinates give the same
     results.
@@ -103,7 +103,7 @@ def test_curvilinear_equivalence():
 
 def test_curvilinear_and_rectilinear():
     """
-    Test :func:`esmf_regrid.schemes.ESMFNearestRegridder`.
+    Test :class:`esmf_regrid.schemes.ESMFNearestRegridder`.
 
     Checks that a cube with both curvilinear and rectilinear coords still works.
     Checks that the DimCoords have priority over AuxCoords.
@@ -156,7 +156,7 @@ def test_curvilinear_and_rectilinear():
 
 def test_unit_equivalence():
     """
-    Test initialisation of :func:`esmf_regrid.schemes.ESMFNearestRegridder`.
+    Test initialisation of :class:`esmf_regrid.schemes.ESMFNearestRegridder`.
 
     Checks that equivalent coordinates in degrees and radians give the same results.
     """
@@ -224,7 +224,7 @@ def test_unit_equivalence():
 
 def test_masks():
     """
-    Test initialisation of :func:`esmf_regrid.schemes.ESMFNearestRegridder`.
+    Test initialisation of :class:`esmf_regrid.schemes.ESMFNearestRegridder`.
 
     Checks that the `use_src_mask` and `use_tgt_mask` keywords work properly.
     """
@@ -268,7 +268,7 @@ def test_masks():
 
 def test_regrid_data():
     """
-    Test initialisation of :func:`esmf_regrid.schemes.ESMFNearestRegridder`.
+    Test initialisation of :class:`esmf_regrid.schemes.ESMFNearestRegridder`.
 
     Checks that regridding mathematics behaves in an expected way.
     """

--- a/esmf_regrid/tests/unit/schemes/test__ESMFRegridder.py
+++ b/esmf_regrid/tests/unit/schemes/test__ESMFRegridder.py
@@ -1,4 +1,4 @@
-"""Unit tests for :func:`esmf_regrid.schemes._ESMFRegridder`."""
+"""Unit tests for :class:`esmf_regrid.schemes._ESMFRegridder`."""
 
 import pytest
 
@@ -10,7 +10,7 @@ from esmf_regrid.tests.unit.schemes.test__cube_to_GridInfo import (
 
 def test_invalid_method():
     """
-    Test initialisation of :func:`esmf_regrid.schemes._ESMFRegridder`.
+    Test initialisation of :class:`esmf_regrid.schemes._ESMFRegridder`.
 
     Checks that an error is raised when the method is invalid.
     """


### PR DESCRIPTION
Creates the minimal version of nearest neighbour regridding described in #213.

This also incidentally fixes a slight error in the refactoring where ESMFBilinear didn't have a `use_src_mask` and `use_tgt_mask` keyword.