### PR TITLE
Introduce enums to replace free text user inputs. 

### DIFF
--- a/esmf_regrid/__init__.py
+++ b/esmf_regrid/__init__.py
@@ -7,7 +7,8 @@ except ImportError as exc:
     except ImportError:
         raise exc
 
-from .schemes import *
 
+from .schemes import *
+from ._constants import Constants
 
 __version__ = "0.6.0"

--- a/esmf_regrid/__init__.py
+++ b/esmf_regrid/__init__.py
@@ -7,8 +7,9 @@ except ImportError as exc:
     except ImportError:
         raise exc
 
-
+# constants is used within schemes, so needs to imported first
+from ._constants import *
 from .schemes import *
-from ._constants import Constants
+
 
 __version__ = "0.6.0"

--- a/esmf_regrid/__init__.py
+++ b/esmf_regrid/__init__.py
@@ -8,7 +8,7 @@ except ImportError as exc:
         raise exc
 
 # constants is used within schemes, so needs to imported first
-from ._constants import *
+from ._constants import Constants
 from .schemes import *
 
 

--- a/esmf_regrid/_constants.py
+++ b/esmf_regrid/_constants.py
@@ -9,5 +9,3 @@ class Constants:
         NEAREST = esmpy.RegridMethod.NEAREST_STOD
 
     NormType = Enum("NormType", ["FRACAREA", "DSTAREA"])
-    # used in other files, placed here to have them all in one place
-    Location = Enum("Location", ["FACE", "NODE"])

--- a/esmf_regrid/_constants.py
+++ b/esmf_regrid/_constants.py
@@ -1,0 +1,12 @@
+from enum import Enum
+from . import esmpy
+
+class Constants():
+    class Method(Enum):
+        CONSERVATIVE = esmpy.RegridMethod.CONSERVE
+        BILINEAR = esmpy.RegridMethod.BILINEAR
+        NEAREST = esmpy.RegridMethod.NEAREST_STOD
+
+    NormType = Enum("NormType", ["FRACAREA", "DSTAREA"])
+    # used in other files, placed here to have them all in one place
+    Location = Enum("Location", ["FACE", "NODE"])

--- a/esmf_regrid/esmf_regridder.py
+++ b/esmf_regrid/esmf_regridder.py
@@ -64,6 +64,8 @@ class Regridder:
         NEAREST = esmpy.RegridMethod.NEAREST_STOD
 
     NormType = Enum("NormType", ["FRACAREA", "DSTAREA"])
+    # used in other files, placed here to have them all in one place
+    Location = Enum("Location", ["FACE", "NODE"])
 
     def __init__(self, src, tgt, method=Method.CONSERVATIVE, precomputed_weights=None):
         """

--- a/esmf_regrid/esmf_regridder.py
+++ b/esmf_regrid/esmf_regridder.py
@@ -145,7 +145,7 @@ class Regridder:
             self.esmf_version = None
             self.weight_matrix = precomputed_weights
 
-    def regrid(self, src_array, norm_type=NormType.FRACERA, mdtol=1):
+    def regrid(self, src_array, norm_type=NormType.FRACAREA, mdtol=1):
         """
         Perform regridding on an array of data.
 

--- a/esmf_regrid/esmf_regridder.py
+++ b/esmf_regrid/esmf_regridder.py
@@ -66,7 +66,7 @@ class Regridder:
 
     NormType = Enum('NormType', ['FRACAREA', 'DSTAREA'])
 
-    def __init__(self, src, tgt, method=None, precomputed_weights=None):
+    def __init__(self, src, tgt, method=Method.CONSERVATIVE, precomputed_weights=None):
         """
         Create a regridder from descriptions of horizontal grids/meshes.
 
@@ -86,11 +86,7 @@ class Regridder:
             Data output by this regridder will be a :class:`numpy.ndarray` whose
             shape is compatible with ``tgt``.
         method : :class:`Regridder.Method`
-            Either Regridder.Method.CONSERVATIVE, Regridder.Method.BILINEAR or Regridder.Method.NEAREST.
-            Corresponds to the :mod:`esmpy` methods
-            :attr:`~esmpy.api.constants.RegridMethod.CONSERVE`,
-            :attr:`~esmpy.api.constants.RegridMethod.BILINEAR` or
-            :attr:`~esmpy.api.constants.RegridMethod.NEAREST_STOD` used to calculate weights.
+            The method to be used to calculate weights.
         precomputed_weights : :class:`scipy.sparse.spmatrix`, optional
             If ``None``, :mod:`esmpy` will be used to
             calculate regridding weights. Otherwise, :mod:`esmpy` will be bypassed
@@ -99,11 +95,9 @@ class Regridder:
         self.src = src
         self.tgt = tgt
 
-        # Sets default value, as this can't be done with class attributes within __init__()
-        if method is None:
-            method = self.Method.CONSERVATIVE
+        # type checks method
         if not isinstance(method, self.Method):
-            raise ValueError("TEMP ERROR MESSAGE")
+            raise ValueError("``method```` must be a member of the ``Regridder.Method`` enum.")
 
         self.esmf_regrid_version = esmf_regrid.__version__
         if precomputed_weights is None:
@@ -148,7 +142,7 @@ class Regridder:
             self.esmf_version = None
             self.weight_matrix = precomputed_weights
 
-    def regrid(self, src_array, norm_type=None, mdtol=1):
+    def regrid(self, src_array, norm_type=NormType.FRACERA, mdtol=1):
         """
         Perform regridding on an array of data.
 
@@ -157,8 +151,8 @@ class Regridder:
         src_array : :obj:`~numpy.typing.ArrayLike`
             Array whose shape is compatible with ``self.src``
         norm_type : :class:`Regridder.NormType`
-            Either ``Regridder.NormType.FRACAREA`` or ``Regridder.NormType.DSTAREA``,
-            defaults to ``Regridder.NormType.FRACAREA``. Determines the
+            Either ``Regridder.NormType.FRACAREA`` or ``Regridder.NormType.DSTAREA``.
+            Determines the
             type of normalisation applied to the weights. Normalisations correspond
             to :mod:`esmpy` constants :attr:`~esmpy.api.constants.NormType.FRACAREA` and
             :attr:`~esmpy.api.constants.NormType.DSTAREA`.
@@ -179,10 +173,8 @@ class Regridder:
 
         """
         # Sets default value, as this can't be done with class attributes within method call
-        if norm_type is None:
-            norm_type = self.NormType.FRACAREA
         if not isinstance(norm_type, self.NormType):
-            raise ValueError("TEMP ERROR MESSAGE")
+            raise ValueError("``norm_type```` must be a member of the ``Regridder.NormType`` enum.")
 
         array_shape = src_array.shape
         main_shape = array_shape[-self.src.dims :]

--- a/esmf_regrid/esmf_regridder.py
+++ b/esmf_regrid/esmf_regridder.py
@@ -152,10 +152,9 @@ class Regridder:
             Array whose shape is compatible with ``self.src``
         norm_type : :class:`Regridder.NormType`
             Either ``Regridder.NormType.FRACAREA`` or ``Regridder.NormType.DSTAREA``.
-            Determines the
-            type of normalisation applied to the weights. Normalisations correspond
-            to :mod:`esmpy` constants :attr:`~esmpy.api.constants.NormType.FRACAREA` and
-            :attr:`~esmpy.api.constants.NormType.DSTAREA`.
+            Determines the type of normalisation applied to the weights. Normalisations
+            correspond to :mod:`esmpy` constants :attr:`~esmpy.api.constants.NormType.FRACAREA`
+            and :attr:`~esmpy.api.constants.NormType.DSTAREA`.
         mdtol : float, default=1
             A number between 0 and 1 describing the missing data tolerance.
             Depending on the value of ``mdtol``, if a cell in the target grid is not

--- a/esmf_regrid/experimental/io.py
+++ b/esmf_regrid/experimental/io.py
@@ -8,6 +8,7 @@ import numpy as np
 import scipy.sparse
 
 import esmf_regrid
+from .. import Constants
 from esmf_regrid.experimental.unstructured_scheme import (
     GridToMeshESMFRegridder,
     MeshToGridESMFRegridder,
@@ -124,7 +125,7 @@ def save_regridder(rg, filename):
     save_version = esmf_regrid.__version__
 
     # Currently, all schemes use the fracarea normalization.
-    normalization = "fracarea"
+    normalization = Constants.NormType.FRACAREA
 
     mdtol = rg.mdtol
     attributes = {
@@ -203,7 +204,7 @@ def load_regridder(filename):
 
     # Determine the regridding method, allowing for files created when
     # conservative regridding was the only method.
-    method = weights_cube.attributes.get(METHOD, "conservative")
+    method = weights_cube.attributes.get(METHOD, Constants.Method.CONSERVATICE)
     resolution = weights_cube.attributes.get(RESOLUTION, None)
     if resolution is not None:
         resolution = int(resolution)

--- a/esmf_regrid/experimental/unstructured_regrid.py
+++ b/esmf_regrid/experimental/unstructured_regrid.py
@@ -1,14 +1,10 @@
 """Provides :mod:`esmpy` representations of UGRID meshes."""
 
 import numpy as np
+from enum import Enum
 
 from .. import esmpy
 from .._esmf_sdo import SDO
-
-
-class Location(Enum):
-    FACE = "face"
-    NODE = "node"
 
 
 class MeshInfo(SDO):
@@ -23,6 +19,10 @@ class MeshInfo(SDO):
     contain enough information for area weighted regridding and may be
     inappropriate for other :mod:`esmpy` regridding schemes.
     """
+
+    class Location(Enum):
+        FACE = "face"
+        NODE = "node"
 
     def __init__(
         self,

--- a/esmf_regrid/experimental/unstructured_regrid.py
+++ b/esmf_regrid/experimental/unstructured_regrid.py
@@ -1,9 +1,9 @@
 """Provides :mod:`esmpy` representations of UGRID meshes."""
 
 import numpy as np
-from enum import Enum
 
 from .. import esmpy
+from .. import Constants
 from .._esmf_sdo import SDO
 
 
@@ -20,10 +20,6 @@ class MeshInfo(SDO):
     inappropriate for other :mod:`esmpy` regridding schemes.
     """
 
-    class Location(Enum):
-        FACE = "face"
-        NODE = "node"
-
     def __init__(
         self,
         node_coords,
@@ -33,7 +29,7 @@ class MeshInfo(SDO):
         areas=None,
         mask=None,
         elem_coords=None,
-        location="face",
+        location=Constants.Location.FACE,
     ):
         """
         Create a :class:`MeshInfo` object describing a UGRID-like mesh.
@@ -68,8 +64,8 @@ class MeshInfo(SDO):
             An ``Nx2`` array describing the location of the face centers of the mesh.
             ``elem_coords[:,0]`` describes the longitudes in degrees and
             ``elem_coords[:,1]`` describes the latitudes in degrees.
-        location : str, default="face"
-            Either "face" or "node". Describes the location for data on the mesh.
+        location : :class:`Constants.Location`
+            Member of Constants.Location enum. Describes the location for data on the mesh.
         """
         self.node_coords = node_coords
         self.fnc = face_node_connectivity
@@ -77,16 +73,16 @@ class MeshInfo(SDO):
         self.esi = elem_start_index
         self.areas = areas
         self.elem_coords = elem_coords
-        if location == "face":
+        if location == Constants.Location.FACE:
             field_kwargs = {"meshloc": esmpy.MeshLoc.ELEMENT}
             shape = (len(face_node_connectivity),)
-        elif location == "node":
+        elif location == Constants.Location.NODE:
             field_kwargs = {"meshloc": esmpy.MeshLoc.NODE}
             shape = (len(node_coords),)
         else:
             raise ValueError(
                 f"The mesh location '{location}' is not supported, only "
-                f"'face' and 'node' are supported."
+                f"members of Constants.Location enum are accepted."
             )
         super().__init__(
             shape=shape,

--- a/esmf_regrid/experimental/unstructured_regrid.py
+++ b/esmf_regrid/experimental/unstructured_regrid.py
@@ -29,7 +29,7 @@ class MeshInfo(SDO):
         areas=None,
         mask=None,
         elem_coords=None,
-        location=Constants.Location.FACE,
+        location="face",
     ):
         """
         Create a :class:`MeshInfo` object describing a UGRID-like mesh.
@@ -73,10 +73,10 @@ class MeshInfo(SDO):
         self.esi = elem_start_index
         self.areas = areas
         self.elem_coords = elem_coords
-        if location == Constants.Location.FACE:
+        if location == "face":
             field_kwargs = {"meshloc": esmpy.MeshLoc.ELEMENT}
             shape = (len(face_node_connectivity),)
-        elif location == Constants.Location.NODE:
+        elif location == "node":
             field_kwargs = {"meshloc": esmpy.MeshLoc.NODE}
             shape = (len(node_coords),)
         else:

--- a/esmf_regrid/experimental/unstructured_regrid.py
+++ b/esmf_regrid/experimental/unstructured_regrid.py
@@ -5,6 +5,9 @@ import numpy as np
 from .. import esmpy
 from .._esmf_sdo import SDO
 
+class Location(Enum):
+    FACE = "face"
+    NODE = "node"
 
 class MeshInfo(SDO):
     """

--- a/esmf_regrid/experimental/unstructured_scheme.py
+++ b/esmf_regrid/experimental/unstructured_scheme.py
@@ -8,13 +8,14 @@ from esmf_regrid.schemes import (
     _regrid_unstructured_to_rectilinear__perform,
     _regrid_unstructured_to_rectilinear__prepare,
 )
+from .. import Constants
 
 
 def regrid_unstructured_to_rectilinear(
     src_cube,
     grid_cube,
     mdtol=0,
-    method="conservative",
+    method=Constants.Method.CONSERVATIVE,
     tgt_resolution=None,
     use_src_mask=False,
     use_tgt_mask=False,
@@ -55,11 +56,8 @@ def regrid_unstructured_to_rectilinear(
         target cell. ``mdtol=0`` means no missing data is tolerated while ``mdtol=1``
         will mean the resulting element will be masked if and only if all the
         overlapping cells of ``src_cube`` are masked.
-    method : str, default="conservative"
-        Either "conservative", "bilinear" or "nearest". Corresponds to the :mod:`esmpy` methods
-        :attr:`~esmpy.api.constants.RegridMethod.CONSERVE` or
-        :attr:`~esmpy.api.constants.RegridMethod.BILINEAR` or
-        :attr:`~esmpy.api.constants.RegridMethod.NEAREST` used to calculate weights.
+    method : :class:`Constants.Method`
+            The method to be used to calculate weights.
     tgt_resolution : int, optional
         If present, represents the amount of latitude slices per cell
         given to ESMF for calculation.
@@ -105,7 +103,7 @@ class MeshToGridESMFRegridder(_ESMFRegridder):
         src,
         tgt,
         mdtol=None,
-        method="conservative",
+        method=Constants.Method,
         precomputed_weights=None,
         tgt_resolution=None,
         use_src_mask=False,
@@ -127,11 +125,8 @@ class MeshToGridESMFRegridder(_ESMFRegridder):
             ``mdtol=1`` will mean the resulting element will be masked if and only
             if all the contributing elements of data are masked. Defaults to 1
             for conservative regregridding and 0 for bilinear regridding.
-        method : str, default="conservative"
-            Either "conservative", "bilinear" or "nearest". Corresponds to the :mod:`esmpy`
-            methods :attr:`~esmpy.api.constants.RegridMethod.CONSERVE` or
-            :attr:`~esmpy.api.constants.RegridMethod.BILINEAR` or
-            :attr:`~esmpy.api.constants.RegridMethod.NEAREST` used to calculate weights.
+        method : :class:`Constants.Method`
+            The method to be used to calculate weights.
         precomputed_weights : :class:`scipy.sparse.spmatrix`, optional
             If ``None``, :mod:`esmpy` will be used to
             calculate regridding weights. Otherwise, :mod:`esmpy` will be bypassed
@@ -181,7 +176,7 @@ def regrid_rectilinear_to_unstructured(
     src_cube,
     mesh_cube,
     mdtol=0,
-    method="conservative",
+    method=Constants.Method.CONSERVATIVE,
     src_resolution=None,
     use_src_mask=False,
     use_tgt_mask=False,
@@ -226,11 +221,8 @@ def regrid_rectilinear_to_unstructured(
         target cell. ``mdtol=0`` means no missing data is tolerated while ``mdtol=1``
         will mean the resulting element will be masked if and only if all the
         overlapping cells of the ``src_cube`` are masked.
-    method : str, default="conservative"
-        Either "conservative", "bilinear" or "nearest". Corresponds to the :mod:`esmpy` methods
-        :attr:`~esmpy.api.constants.RegridMethod.CONSERVE` or
-        :attr:`~esmpy.api.constants.RegridMethod.BILINEAR` or
-        :attr:`~esmpy.api.constants.RegridMethod.NEAREST` used to calculate weights.
+    method : :class:`Constants.Method`
+            The method to be used to calculate weights.
     src_resolution : int, optional
         If present, represents the amount of latitude slices per cell
         given to ESMF for calculation.
@@ -276,7 +268,7 @@ class GridToMeshESMFRegridder(_ESMFRegridder):
         src,
         tgt,
         mdtol=None,
-        method="conservative",
+        method=Constants.Method.CONSERVATIVE,
         precomputed_weights=None,
         src_resolution=None,
         use_src_mask=False,
@@ -298,11 +290,8 @@ class GridToMeshESMFRegridder(_ESMFRegridder):
             ``mdtol=1`` will mean the resulting element will be masked if and only
             if all the contributing elements of data are masked. Defaults to 1
             for conservative regregridding and 0 for bilinear regridding.
-        method : str, default="conservative"
-            Either "conservative", "bilinear" or "nearest". Corresponds to the :mod:`esmpy`
-            methods :attr:`~esmpy.api.constants.RegridMethod.CONSERVE` or
-            :attr:`~esmpy.api.constants.RegridMethod.BILINEAR` or
-            :attr:`~esmpy.api.constants.RegridMethod.NEAREST` used to calculate weights.
+        method : :class:`Constants.Method`
+            The method to be used to calculate weights.
         precomputed_weights : :class:`scipy.sparse.spmatrix`, optional
             If ``None``, :mod:`esmpy` will be used to
             calculate regridding weights. Otherwise, :mod:`esmpy` will be bypassed

--- a/esmf_regrid/schemes.py
+++ b/esmf_regrid/schemes.py
@@ -3,6 +3,7 @@
 from collections import namedtuple
 import copy
 import functools
+from enum import Enum
 
 from cf_units import Unit
 import dask.array as da
@@ -24,6 +25,14 @@ __all__ = [
     "regrid_rectilinear_to_rectilinear",
 ]
 
+class Method(Enum):
+    CONSERVATIVE = "conservative"
+    BILINEAR = "bilinear"
+    NEAREST = "nearest"
+
+class Location(Enum):
+    FACE = "face"
+    NODE = "node"
 
 def _get_coord(cube, axis):
     try:

--- a/esmf_regrid/schemes.py
+++ b/esmf_regrid/schemes.py
@@ -478,12 +478,12 @@ def _make_meshinfo(cube, method, mask, src_or_tgt):
                 f"the face of a cube, target cube had the {location} location."
             )
     elif method in (Constants.Method.BILINEAR, Constants.Method.NEAREST):
-        if location not in [Constants.Location.FACE, Constants.Location.NODE]:
+        if location not in ["face", "face"]:
             raise ValueError(
                 f"{method} regridding requires a {src_or_tgt} cube with a node "
                 f"or face location, target cube had the {location} location."
             )
-        if location == Constants.Location.FACE and None in mesh.face_coords:
+        if location == "face" and None in mesh.face_coords:
             raise ValueError(
                 f"{method} regridding requires a {src_or_tgt} cube on a face"
                 f"location to have a face center."

--- a/esmf_regrid/schemes.py
+++ b/esmf_regrid/schemes.py
@@ -25,6 +25,7 @@ __all__ = [
     "regrid_rectilinear_to_rectilinear",
 ]
 
+
 def _get_coord(cube, axis):
     try:
         coord = cube.coord(axis=axis, dim_coords=True)
@@ -1122,7 +1123,9 @@ class _ESMFRegridder:
 
         """
         if not isinstance(method, Regridder.Method):
-            raise ValueError("``method```` must be a member of the ``Regridder.Method`` enum.")
+            raise ValueError(
+                "``method```` must be a member of the ``Regridder.Method`` enum."
+            )
         if mdtol is None:
             if method == Regridder.Method.CONSERVATIVE:
                 mdtol = 1

--- a/esmf_regrid/schemes.py
+++ b/esmf_regrid/schemes.py
@@ -478,7 +478,7 @@ def _make_meshinfo(cube, method, mask, src_or_tgt):
                 f"the face of a cube, target cube had the {location} location."
             )
     elif method in (Constants.Method.BILINEAR, Constants.Method.NEAREST):
-        if location not in ["face", "face"]:
+        if location not in ["face", "node"]:
             raise ValueError(
                 f"{method} regridding requires a {src_or_tgt} cube with a node "
                 f"or face location, target cube had the {location} location."

--- a/esmf_regrid/schemes.py
+++ b/esmf_regrid/schemes.py
@@ -10,6 +10,7 @@ import iris.coords
 import iris.cube
 from iris.exceptions import CoordinateNotFoundError
 import numpy as np
+from . import Constants
 
 from esmf_regrid.esmf_regridder import GridInfo, RefinedGridInfo, Regridder
 from esmf_regrid.experimental.unstructured_regrid import MeshInfo
@@ -452,15 +453,15 @@ def _make_gridinfo(cube, method, resolution, mask):
     if resolution is not None:
         if not (isinstance(resolution, int) and resolution > 0):
             raise ValueError("resolution must be a positive integer.")
-        if method != Regridder.Method.CONSERVATIVE:
+        if method != Constants.Method.CONSERVATIVE:
             raise ValueError("resolution can only be set for conservative regridding.")
-    if method == Regridder.Method.CONSERVATIVE:
+    if method == Constants.Method.CONSERVATIVE:
         center = False
-    elif method in (Regridder.Method.BILINEAR, Regridder.Method.NEAREST):
+    elif method in (Constants.Method.BILINEAR, Constants.Method.NEAREST):
         center = True
     else:
         raise NotImplementedError(
-            f"method must be a member of the Regridder.Method enum, got '{method}'."
+            f"method must be a member of the Constants.Method enum, got '{method}'."
         )
     return _cube_to_GridInfo(cube, center=center, resolution=resolution, mask=mask)
 
@@ -470,26 +471,26 @@ def _make_meshinfo(cube, method, mask, src_or_tgt):
     location = cube.location
     if mesh is None:
         raise ValueError(f"The {src_or_tgt} cube is not defined on a mesh.")
-    if method == Regridder.Method.CONSERVATIVE:
+    if method == Constants.Method.CONSERVATIVE:
         if location != "face":
             raise ValueError(
                 f"Conservative regridding requires a {src_or_tgt} cube located on "
                 f"the face of a cube, target cube had the {location} location."
             )
-    elif method in (Regridder.Method.BILINEAR, Regridder.Method.NEAREST):
-        if location not in [Regridder.Location.FACE, Regridder.Location.NODE]:
+    elif method in (Constants.Method.BILINEAR, Constants.Method.NEAREST):
+        if location not in [Constants.Location.FACE, Constants.Location.NODE]:
             raise ValueError(
                 f"{method} regridding requires a {src_or_tgt} cube with a node "
                 f"or face location, target cube had the {location} location."
             )
-        if location == Regridder.Location.FACE and None in mesh.face_coords:
+        if location == Constants.Location.FACE and None in mesh.face_coords:
             raise ValueError(
                 f"{method} regridding requires a {src_or_tgt} cube on a face"
                 f"location to have a face center."
             )
     else:
         raise NotImplementedError(
-            f"method must be a member of Regridder.Method enum, got '{method}'."
+            f"method must be a member of Constants.Method enum, got '{method}'."
         )
 
     return _mesh_to_MeshInfo(mesh, location, mask=mask)
@@ -767,7 +768,7 @@ def regrid_rectilinear_to_rectilinear(
     src_cube,
     grid_cube,
     mdtol=0,
-    method=Regridder.Method.CONSERVATIVE,
+    method=Constants.Method.CONSERVATIVE,
     src_resolution=None,
     tgt_resolution=None,
 ):
@@ -796,7 +797,7 @@ def regrid_rectilinear_to_rectilinear(
         target cell. ``mdtol=0`` means no missing data is tolerated while ``mdtol=1``
         will mean the resulting element will be masked if and only if all the
         overlapping cells of ``src_cube`` are masked.
-    method : :class:`Regridder.Method`
+    method : :class:`Constants.Method`
         The method to be used to calculate weights.
     src_resolution, tgt_resolution : int, optional
         If present, represents the amount of latitude slices per source/target cell
@@ -1099,7 +1100,7 @@ class _ESMFRegridder:
             The rectilinear :class:`~iris.cube.Cube` providing the source grid.
         tgt : :class:`iris.cube.Cube`
             The rectilinear :class:`~iris.cube.Cube` providing the target grid.
-        method : :class:`Regridder.Method`
+        method : :class:`Constants.Method`
             The method to be used to calculate weights.
         mdtol : float, default=None
             Tolerance of missing data. The value returned in each element of
@@ -1121,14 +1122,14 @@ class _ESMFRegridder:
             or ``tgt`` respectively are not constant over non-horizontal dimensions.
 
         """
-        if not isinstance(method, Regridder.Method):
+        if not isinstance(method, Constants.Method):
             raise ValueError(
-                "``method```` must be a member of the ``Regridder.Method`` enum."
+                "``method```` must be a member of the ``Constants.Method`` enum."
             )
         if mdtol is None:
-            if method == Regridder.Method.CONSERVATIVE:
+            if method == Constants.Method.CONSERVATIVE:
                 mdtol = 1
-            elif method in (Regridder.Method.NEAREST, Regridder.Method.BILINEAR):
+            elif method in (Constants.Method.NEAREST, Constants.Method.BILINEAR):
                 mdtol = 0
         if not (0 <= mdtol <= 1):
             msg = "Value for mdtol must be in range 0 - 1, got {}."
@@ -1310,7 +1311,7 @@ class ESMFAreaWeightedRegridder(_ESMFRegridder):
         super().__init__(
             src,
             tgt,
-            Regridder.Method.CONSERVATIVE,
+            Constants.Method.CONSERVATIVE,
             mdtol=mdtol,
             precomputed_weights=precomputed_weights,
             **kwargs,
@@ -1363,7 +1364,7 @@ class ESMFBilinearRegridder(_ESMFRegridder):
         super().__init__(
             src,
             tgt,
-            Regridder.Method.BILINEAR,
+            Constants.Method.BILINEAR,
             mdtol=mdtol,
             precomputed_weights=precomputed_weights,
             use_src_mask=use_src_mask,
@@ -1410,7 +1411,7 @@ class ESMFNearestRegridder(_ESMFRegridder):
         super().__init__(
             src,
             tgt,
-            Regridder.Method.NEAREST,
+            Constants.Method.NEAREST,
             mdtol=0,
             precomputed_weights=precomputed_weights,
             use_src_mask=use_src_mask,

--- a/esmf_regrid/schemes.py
+++ b/esmf_regrid/schemes.py
@@ -3,7 +3,6 @@
 from collections import namedtuple
 import copy
 import functools
-from enum import Enum
 
 from cf_units import Unit
 import dask.array as da
@@ -1311,7 +1310,7 @@ class ESMFAreaWeightedRegridder(_ESMFRegridder):
         super().__init__(
             src,
             tgt,
-            "conservative",
+            Regridder.Method.CONSERVATIVE,
             mdtol=mdtol,
             precomputed_weights=precomputed_weights,
             **kwargs,
@@ -1364,7 +1363,7 @@ class ESMFBilinearRegridder(_ESMFRegridder):
         super().__init__(
             src,
             tgt,
-            "bilinear",
+            Regridder.Method.BILINEAR,
             mdtol=mdtol,
             precomputed_weights=precomputed_weights,
             use_src_mask=use_src_mask,
@@ -1411,7 +1410,7 @@ class ESMFNearestRegridder(_ESMFRegridder):
         super().__init__(
             src,
             tgt,
-            "nearest",
+            Regridder.Method.NEAREST,
             mdtol=0,
             precomputed_weights=precomputed_weights,
             use_src_mask=use_src_mask,

--- a/esmf_regrid/schemes.py
+++ b/esmf_regrid/schemes.py
@@ -25,18 +25,6 @@ __all__ = [
     "regrid_rectilinear_to_rectilinear",
 ]
 
-
-class Method(Enum):
-    CONSERVATIVE = "conservative"
-    BILINEAR = "bilinear"
-    NEAREST = "nearest"
-
-
-class Location(Enum):
-    FACE = "face"
-    NODE = "node"
-
-
 def _get_coord(cube, axis):
     try:
         coord = cube.coord(axis=axis, dim_coords=True)
@@ -464,15 +452,15 @@ def _make_gridinfo(cube, method, resolution, mask):
     if resolution is not None:
         if not (isinstance(resolution, int) and resolution > 0):
             raise ValueError("resolution must be a positive integer.")
-        if method != "conservative":
+        if method != Regridder.Method.CONSERVATIVE:
             raise ValueError("resolution can only be set for conservative regridding.")
-    if method == "conservative":
+    if method == Regridder.Method.CONSERVATIVE:
         center = False
-    elif method in ("bilinear", "nearest"):
+    elif method in (Regridder.Method.BILINEAR, Regridder.Method.NEAREST):
         center = True
     else:
         raise NotImplementedError(
-            f"method must be either 'bilinear', 'conservative' or 'nearest', got '{method}'."
+            f"method must be a member of the Regridder.Method enum, got '{method}'."
         )
     return _cube_to_GridInfo(cube, center=center, resolution=resolution, mask=mask)
 
@@ -482,26 +470,26 @@ def _make_meshinfo(cube, method, mask, src_or_tgt):
     location = cube.location
     if mesh is None:
         raise ValueError(f"The {src_or_tgt} cube is not defined on a mesh.")
-    if method == "conservative":
+    if method == Regridder.Method.CONSERVATIVE:
         if location != "face":
             raise ValueError(
                 f"Conservative regridding requires a {src_or_tgt} cube located on "
                 f"the face of a cube, target cube had the {location} location."
             )
-    elif method in ("bilinear", "nearest"):
-        if location not in ["face", "node"]:
+    elif method in (Regridder.Method.BILINEAR, Regridder.Method.NEAREST):
+        if location not in [Regridder.Location.FACE, Regridder.Location.NODE]:
             raise ValueError(
                 f"{method} regridding requires a {src_or_tgt} cube with a node "
                 f"or face location, target cube had the {location} location."
             )
-        if location == "face" and None in mesh.face_coords:
+        if location == Regridder.Location.FACE and None in mesh.face_coords:
             raise ValueError(
                 f"{method} regridding requires a {src_or_tgt} cube on a face"
                 f"location to have a face center."
             )
     else:
         raise NotImplementedError(
-            f"method must be either 'bilinear', 'conservative' or 'nearest', got '{method}'."
+            f"method must be a member of Regridder.Method enum, got '{method}'."
         )
 
     return _mesh_to_MeshInfo(mesh, location, mask=mask)
@@ -779,7 +767,7 @@ def regrid_rectilinear_to_rectilinear(
     src_cube,
     grid_cube,
     mdtol=0,
-    method="conservative",
+    method=Regridder.Method.CONSERVATIVE,
     src_resolution=None,
     tgt_resolution=None,
 ):
@@ -808,11 +796,8 @@ def regrid_rectilinear_to_rectilinear(
         target cell. ``mdtol=0`` means no missing data is tolerated while ``mdtol=1``
         will mean the resulting element will be masked if and only if all the
         overlapping cells of ``src_cube`` are masked.
-    method : str, default="conservative"
-        Either "conservative", "bilinear" or "nearest". Corresponds to the :mod:`esmpy` methods
-        :attr:`~esmpy.api.constants.RegridMethod.CONSERVE`,
-        :attr:`~esmpy.api.constants.RegridMethod.BILINEAR` or
-        :attr:`~esmpy.api.constants.RegridMethod.NEAREST_STOD` used to calculate weights.
+    method : :class:`Regridder.Method`
+        The method to be used to calculate weights.
     src_resolution, tgt_resolution : int, optional
         If present, represents the amount of latitude slices per source/target cell
         given to ESMF for calculation.
@@ -1114,11 +1099,8 @@ class _ESMFRegridder:
             The rectilinear :class:`~iris.cube.Cube` providing the source grid.
         tgt : :class:`iris.cube.Cube`
             The rectilinear :class:`~iris.cube.Cube` providing the target grid.
-        method : str
-        Either "conservative", "bilinear" or "nearest". Corresponds to the :mod:`esmpy` methods
-        :attr:`~esmpy.api.constants.RegridMethod.CONSERVE`,
-        :attr:`~esmpy.api.constants.RegridMethod.BILINEAR` or
-        :attr:`~esmpy.api.constants.RegridMethod.NEAREST_STOD` used to calculate weights.
+        method : :class:`Regridder.Method`
+            The method to be used to calculate weights.
         mdtol : float, default=None
             Tolerance of missing data. The value returned in each element of
             the returned array will be masked if the fraction of masked data
@@ -1139,14 +1121,12 @@ class _ESMFRegridder:
             or ``tgt`` respectively are not constant over non-horizontal dimensions.
 
         """
-        if method not in ["conservative", "bilinear", "nearest"]:
-            raise NotImplementedError(
-                f"method must be either 'bilinear', 'conservative' or 'nearest', got '{method}'."
-            )
+        if not isinstance(method, Regridder.Method):
+            raise ValueError("``method```` must be a member of the ``Regridder.Method`` enum.")
         if mdtol is None:
-            if method == "conservative":
+            if method == Regridder.Method.CONSERVATIVE:
                 mdtol = 1
-            elif method in ("bilinear", "nearest"):
+            elif method in (Regridder.Method.NEAREST, Regridder.Method.BILINEAR):
                 mdtol = 0
         if not (0 <= mdtol <= 1):
             msg = "Value for mdtol must be in range 0 - 1, got {}."

--- a/esmf_regrid/tests/integration/esmf_regridder/test_Regridder.py
+++ b/esmf_regrid/tests/integration/esmf_regridder/test_Regridder.py
@@ -3,6 +3,7 @@
 import numpy as np
 from numpy import ma
 
+from esmf_regrid import Constants
 from esmf_regrid import esmpy
 from esmf_regrid.esmf_regridder import GridInfo, Regridder
 from esmf_regrid.tests import make_grid_args

--- a/esmf_regrid/tests/integration/esmf_regridder/test_Regridder.py
+++ b/esmf_regrid/tests/integration/esmf_regridder/test_Regridder.py
@@ -60,10 +60,10 @@ def test_esmpy_normalisation():
 
     tgt_field_dstarea = esmpy_dstarea_regridder(src_field, tgt_field)
     result_esmpy_dstarea = tgt_field_dstarea.data
-    result_dstarea = regridder.regrid(src_array, norm_type="dstarea")
+    result_dstarea = regridder.regrid(src_array, norm_type=Regridder.NormType.DSTAREA)
     assert ma.allclose(result_esmpy_dstarea, result_dstarea)
 
     tgt_field_fracarea = esmpy_fracarea_regridder(src_field, tgt_field)
     result_esmpy_fracarea = tgt_field_fracarea.data
-    result_fracarea = regridder.regrid(src_array, norm_type="fracarea")
+    result_fracarea = regridder.regrid(src_array, norm_type=Regridder.NormType.FRACAREA)
     assert ma.allclose(result_esmpy_fracarea, result_fracarea)

--- a/esmf_regrid/tests/integration/esmf_regridder/test_Regridder.py
+++ b/esmf_regrid/tests/integration/esmf_regridder/test_Regridder.py
@@ -60,10 +60,10 @@ def test_esmpy_normalisation():
 
     tgt_field_dstarea = esmpy_dstarea_regridder(src_field, tgt_field)
     result_esmpy_dstarea = tgt_field_dstarea.data
-    result_dstarea = regridder.regrid(src_array, norm_type=Regridder.NormType.DSTAREA)
+    result_dstarea = regridder.regrid(src_array, norm_type=Constants.NormType.DSTAREA)
     assert ma.allclose(result_esmpy_dstarea, result_dstarea)
 
     tgt_field_fracarea = esmpy_fracarea_regridder(src_field, tgt_field)
     result_esmpy_fracarea = tgt_field_fracarea.data
-    result_fracarea = regridder.regrid(src_array, norm_type=Regridder.NormType.FRACAREA)
+    result_fracarea = regridder.regrid(src_array, norm_type=Constants.NormType.FRACAREA)
     assert ma.allclose(result_esmpy_fracarea, result_fracarea)

--- a/esmf_regrid/tests/unit/esmf_regridder/test_Regridder.py
+++ b/esmf_regrid/tests/unit/esmf_regridder/test_Regridder.py
@@ -116,8 +116,8 @@ def test_Regridder_regrid():
     )
     assert ma.allclose(result_half_mdtol, expected_half_mdtol)
 
-    # Regrid with norm_type="dstarea".
-    result_dstarea = rg.regrid(src_masked, norm_type="dstarea")
+    # Regrid with norm_type=Regridder.NormType.DSTAREA.
+    result_dstarea = rg.regrid(src_masked, norm_type=Regridder.NormType.DSTAREA)
     expected_dstarea = ma.array(
         [
             [0.3325805974343169, 0.4999999999999999, 0.6674194025656823],

--- a/esmf_regrid/tests/unit/esmf_regridder/test_Regridder.py
+++ b/esmf_regrid/tests/unit/esmf_regridder/test_Regridder.py
@@ -4,7 +4,7 @@ import numpy as np
 from numpy import ma
 import pytest
 import scipy.sparse
-
+from esmf_regrid import Constants
 from esmf_regrid.esmf_regridder import GridInfo, Regridder
 from esmf_regrid.tests import make_grid_args
 
@@ -116,8 +116,8 @@ def test_Regridder_regrid():
     )
     assert ma.allclose(result_half_mdtol, expected_half_mdtol)
 
-    # Regrid with norm_type=Regridder.NormType.DSTAREA.
-    result_dstarea = rg.regrid(src_masked, norm_type=Regridder.NormType.DSTAREA)
+    # Regrid with norm_type=Constants.NormType.DSTAREA.
+    result_dstarea = rg.regrid(src_masked, norm_type=Constants.NormType.DSTAREA)
     expected_dstarea = ma.array(
         [
             [0.3325805974343169, 0.4999999999999999, 0.6674194025656823],

--- a/esmf_regrid/tests/unit/experimental/io/test_round_tripping.py
+++ b/esmf_regrid/tests/unit/experimental/io/test_round_tripping.py
@@ -5,6 +5,7 @@ from numpy import ma
 import pytest
 
 from esmf_regrid.experimental.io import load_regridder, save_regridder
+from esmf_regrid._constants import Constants
 from esmf_regrid.experimental.unstructured_scheme import (
     GridToMeshESMFRegridder,
     MeshToGridESMFRegridder,
@@ -19,7 +20,7 @@ from esmf_regrid.tests.unit.schemes.test__mesh_to_MeshInfo import (
 
 
 def _make_grid_to_mesh_regridder(
-    method="conservative",
+    method=Constants.Method.CONSERVATIVE,
     resolution=None,
     grid_dims=1,
     circular=True,
@@ -40,10 +41,10 @@ def _make_grid_to_mesh_regridder(
         src = _curvilinear_cube(src_lons, src_lats, lon_bounds, lat_bounds)
     src.coord("longitude").var_name = "longitude"
     src.coord("latitude").var_name = "latitude"
-    if method == "bilinear":
-        location = "node"
+    if method == Constants.Method.BILINEAR:
+        location = Constants.Location.NODE
     else:
-        location = "face"
+        location = Constants.Location.FACE
     tgt = _gridlike_mesh_cube(tgt_lons, tgt_lats, location=location)
 
     if masks:
@@ -72,7 +73,7 @@ def _make_grid_to_mesh_regridder(
 
 
 def _make_mesh_to_grid_regridder(
-    method="conservative", resolution=None, grid_dims=1, circular=True, masks=False
+    method=Constants.Method.CONSERVATIVE, resolution=None, grid_dims=1, circular=True, masks=False
 ):
     src_lons = 3
     src_lats = 4
@@ -86,10 +87,10 @@ def _make_mesh_to_grid_regridder(
         tgt = _curvilinear_cube(tgt_lons, tgt_lats, lon_bounds, lat_bounds)
     tgt.coord("longitude").var_name = "longitude"
     tgt.coord("latitude").var_name = "latitude"
-    if method == "bilinear":
-        location = "node"
+    if method == Constants.Method.BILINEAR:
+        location = Constants.Location.NODE
     else:
-        location = "face"
+        location = Constants.Location.FACE
     src = _gridlike_mesh_cube(src_lons, src_lats, location=location)
 
     if masks:
@@ -117,7 +118,8 @@ def _make_mesh_to_grid_regridder(
     return rg, src
 
 
-@pytest.mark.parametrize("method", ["conservative", "bilinear", "nearest"])
+@pytest.mark.parametrize("method", [Constants.Method.CONSERVATIVE, Constants.Location.BILINEAR,
+                                    Constants.Method.NEAREST])
 def test_GridToMeshESMFRegridder_round_trip(tmp_path, method):
     """Test save/load round tripping for `GridToMeshESMFRegridder`."""
     original_rg, src = _make_grid_to_mesh_regridder(method=method, circular=True)
@@ -157,7 +159,7 @@ def test_GridToMeshESMFRegridder_round_trip(tmp_path, method):
         == loaded_rg.regridder.esmf_regrid_version
     )
 
-    if method == "conservative":
+    if method == Constants.Method.CONSERVATIVE:
         # Ensure resolution is equal.
         assert original_rg.resolution == loaded_rg.resolution
         original_res_rg, _ = _make_grid_to_mesh_regridder(method=method, resolution=8)
@@ -225,7 +227,8 @@ def test_MeshESMFRegridder_masked_round_trip(tmp_path, rg_maker):
     assert np.array_equal(loaded_rg.tgt_mask, original_rg.tgt_mask)
 
 
-@pytest.mark.parametrize("method", ["conservative", "bilinear", "nearest"])
+@pytest.mark.parametrize("method", [Constants.Method.CONSERVATIVE, Constants.Location.BILINEAR,
+                                    Constants.Method.NEAREST])
 def test_MeshToGridESMFRegridder_round_trip(tmp_path, method):
     """Test save/load round tripping for `MeshToGridESMFRegridder`."""
     original_rg, src = _make_mesh_to_grid_regridder(method=method, circular=True)
@@ -264,7 +267,7 @@ def test_MeshToGridESMFRegridder_round_trip(tmp_path, method):
         == loaded_rg.regridder.esmf_regrid_version
     )
 
-    if method == "conservative":
+    if method == Constants.Method.CONSERVATIVE:
         # Ensure resolution is equal.
         assert original_rg.resolution == loaded_rg.resolution
         original_res_rg, _ = _make_mesh_to_grid_regridder(method=method, resolution=8)

--- a/esmf_regrid/tests/unit/experimental/io/test_round_tripping.py
+++ b/esmf_regrid/tests/unit/experimental/io/test_round_tripping.py
@@ -5,7 +5,7 @@ from numpy import ma
 import pytest
 
 from esmf_regrid.experimental.io import load_regridder, save_regridder
-from esmf_regrid._constants import Constants
+from esmf_regrid import Constants
 from esmf_regrid.experimental.unstructured_scheme import (
     GridToMeshESMFRegridder,
     MeshToGridESMFRegridder,

--- a/esmf_regrid/tests/unit/experimental/io/test_round_tripping.py
+++ b/esmf_regrid/tests/unit/experimental/io/test_round_tripping.py
@@ -42,9 +42,9 @@ def _make_grid_to_mesh_regridder(
     src.coord("longitude").var_name = "longitude"
     src.coord("latitude").var_name = "latitude"
     if method == Constants.Method.BILINEAR:
-        location = Constants.Location.NODE
+        location = "node"
     else:
-        location = Constants.Location.FACE
+        location = "face"
     tgt = _gridlike_mesh_cube(tgt_lons, tgt_lats, location=location)
 
     if masks:
@@ -92,9 +92,9 @@ def _make_mesh_to_grid_regridder(
     tgt.coord("longitude").var_name = "longitude"
     tgt.coord("latitude").var_name = "latitude"
     if method == Constants.Method.BILINEAR:
-        location = Constants.Location.NODE
+        location = "node"
     else:
-        location = Constants.Location.FACE
+        location = "face"
     src = _gridlike_mesh_cube(src_lons, src_lats, location=location)
 
     if masks:
@@ -126,7 +126,7 @@ def _make_mesh_to_grid_regridder(
     "method",
     [
         Constants.Method.CONSERVATIVE,
-        Constants.Location.BILINEAR,
+        Constants.Method.BILINEAR,
         Constants.Method.NEAREST,
     ],
 )
@@ -241,7 +241,7 @@ def test_MeshESMFRegridder_masked_round_trip(tmp_path, rg_maker):
     "method",
     [
         Constants.Method.CONSERVATIVE,
-        Constants.Location.BILINEAR,
+        Constants.Method.BILINEAR,
         Constants.Method.NEAREST,
     ],
 )

--- a/esmf_regrid/tests/unit/experimental/unstructured_regrid/test_MeshInfo.py
+++ b/esmf_regrid/tests/unit/experimental/unstructured_regrid/test_MeshInfo.py
@@ -99,9 +99,9 @@ def test_regrid_bilinear_with_mesh():
     #     0  10
     mesh_args = _make_small_mesh_args()
     elem_coords = np.array([[5, 0], [5, 10]])
-    node_mesh = MeshInfo(*mesh_args, location=Constants.Location.NODE)
+    node_mesh = MeshInfo(*mesh_args, location="face")
     face_mesh = MeshInfo(
-        *mesh_args, elem_coords=elem_coords, location=Constants.Location.FACE
+        *mesh_args, elem_coords=elem_coords, location="face"
     )
 
     # We create a grid with the following shape:

--- a/esmf_regrid/tests/unit/experimental/unstructured_regrid/test_MeshInfo.py
+++ b/esmf_regrid/tests/unit/experimental/unstructured_regrid/test_MeshInfo.py
@@ -3,6 +3,7 @@
 import numpy as np
 from numpy import ma
 
+from esmf_regrid._constants import Constants
 from esmf_regrid.esmf_regridder import GridInfo, Regridder
 from esmf_regrid.experimental.unstructured_regrid import MeshInfo
 from esmf_regrid.tests import get_result_path, make_grid_args
@@ -98,8 +99,8 @@ def test_regrid_bilinear_with_mesh():
     #     0  10
     mesh_args = _make_small_mesh_args()
     elem_coords = np.array([[5, 0], [5, 10]])
-    node_mesh = MeshInfo(*mesh_args, location="node")
-    face_mesh = MeshInfo(*mesh_args, elem_coords=elem_coords, location="face")
+    node_mesh = MeshInfo(*mesh_args, location=Constants.Location.NODE)
+    face_mesh = MeshInfo(*mesh_args, elem_coords=elem_coords, location=Constants.Location.FACE)
 
     # We create a grid with the following shape:
     # 20/3 +---+
@@ -111,7 +112,7 @@ def test_regrid_bilinear_with_mesh():
     grid_args = [ar * 2 for ar in make_grid_args(2, 3)]
     grid = GridInfo(*grid_args, center=True)
 
-    mesh_to_grid_regridder = Regridder(node_mesh, grid, method="bilinear")
+    mesh_to_grid_regridder = Regridder(node_mesh, grid, method=Constants.Method.BILINEAR)
     mesh_input = np.arange(5)
     grid_output = mesh_to_grid_regridder.regrid(mesh_input)
     # For a flat surface, we would expect the fractional part of these values
@@ -132,13 +133,13 @@ def test_regrid_bilinear_with_mesh():
     expected_grid_output = ma.array(expected_grid_output, mask=expected_grid_mask)
     assert ma.allclose(expected_grid_output, grid_output)
 
-    grid_to_mesh_regridder = Regridder(grid, node_mesh, method="bilinear")
+    grid_to_mesh_regridder = Regridder(grid, node_mesh, method=Constants.Method.BILINEAR)
     grid_input = np.array([[0, 0], [1, 0], [2, 1]])
     mesh_output = grid_to_mesh_regridder.regrid(grid_input)
     expected_mesh_output = ma.array([0.0, 1.5, 0.0, 0.5, -1], mask=[0, 0, 0, 0, 1])
     assert ma.allclose(expected_mesh_output, mesh_output)
 
-    grid_to_face_mesh_regridder = Regridder(grid, face_mesh, method="bilinear")
+    grid_to_face_mesh_regridder = Regridder(grid, face_mesh, method=Constants.Method.BILINEAR)
     grid_input_2 = np.array([[0, 0], [1, 0], [4, 1]])
     face_mesh_output = grid_to_face_mesh_regridder.regrid(grid_input_2)
     expected_face_mesh_output = np.array([0.0, 1.4888258584989558])

--- a/esmf_regrid/tests/unit/experimental/unstructured_scheme/test_GridToMeshESMFRegridder.py
+++ b/esmf_regrid/tests/unit/experimental/unstructured_scheme/test_GridToMeshESMFRegridder.py
@@ -80,7 +80,7 @@ def test_node_friendly_methods(method):
     """
     Basic test for :class:`esmf_regrid.experimental.unstructured_scheme.GridToMeshESMFRegridder`.
 
-    Tests with method="bilinear" and method="nearest".
+    Tests with method=Constants.Method.BILINEAR and method=Constants.Method.NEAREST.
     """
     n_lons = 6
     n_lats = 5
@@ -210,14 +210,14 @@ def test_invalid_method():
     )
     assert expected_message in str(excinfo.value)
     with pytest.raises(ValueError) as excinfo:
-        _ = GridToMeshESMFRegridder(src, edge_tgt, method="bilinear")
+        _ = GridToMeshESMFRegridder(src, edge_tgt, method=Constants.Method.BILINEAR)
     expected_message = (
         "bilinear regridding requires a target cube with a node "
         "or face location, target cube had the edge location."
     )
     assert expected_message in str(excinfo.value)
     with pytest.raises(ValueError) as excinfo:
-        _ = GridToMeshESMFRegridder(src, edge_tgt, method="nearest")
+        _ = GridToMeshESMFRegridder(src, edge_tgt, method=Constants.Method.NEAREST)
     expected_message = (
         "nearest regridding requires a target cube with a node "
         "or face location, target cube had the edge location."
@@ -239,12 +239,12 @@ def test_invalid_resolution():
     src = _grid_cube(n_lons, n_lats, lon_bounds, lat_bounds, circular=True)
 
     with pytest.raises(ValueError) as excinfo:
-        _ = GridToMeshESMFRegridder(src, tgt, method="conservative", src_resolution=-1)
+        _ = GridToMeshESMFRegridder(src, tgt, method=Constants.Method.CONSERVATIVE, src_resolution=-1)
     expected_message = "resolution must be a positive integer."
     assert expected_message in str(excinfo.value)
 
     with pytest.raises(ValueError) as excinfo:
-        _ = GridToMeshESMFRegridder(src, tgt, method="bilinear", src_resolution=4)
+        _ = GridToMeshESMFRegridder(src, tgt, method=Constants.Method.BILINEAR, src_resolution=4)
     expected_message = "resolution can only be set for conservative regridding."
     assert expected_message in str(excinfo.value)
 
@@ -262,9 +262,9 @@ def test_default_mdtol():
     tgt = _gridlike_mesh_cube(n_lons, n_lats)
     src = _grid_cube(n_lons, n_lats, lon_bounds, lat_bounds, circular=True)
 
-    rg_con = GridToMeshESMFRegridder(src, tgt, method="conservative")
+    rg_con = GridToMeshESMFRegridder(src, tgt, method=Constants.Method.CONSERVATIVE)
     assert rg_con.mdtol == 1
-    rg_bi = GridToMeshESMFRegridder(src, tgt, method="bilinear")
+    rg_bi = GridToMeshESMFRegridder(src, tgt, method=Constants.Method.BILINEAR)
     assert rg_bi.mdtol == 0
 
 

--- a/esmf_regrid/tests/unit/experimental/unstructured_scheme/test_GridToMeshESMFRegridder.py
+++ b/esmf_regrid/tests/unit/experimental/unstructured_scheme/test_GridToMeshESMFRegridder.py
@@ -75,9 +75,7 @@ def test_flat_cubes():
     assert expected_cube == result_transposed
 
 
-@pytest.mark.parametrize(
-    "method", [Constants.Method.BILINEAR, Constants.Method.NEAREST]
-)
+@pytest.mark.parametrize("method", [Constants.Method.BILINEAR, Constants.Method.NEAREST])
 def test_node_friendly_methods(method):
     """
     Basic test for :class:`esmf_regrid.experimental.unstructured_scheme.GridToMeshESMFRegridder`.
@@ -155,7 +153,7 @@ def test_multidim_cubes():
     expected_data[:] = np.arange(t * h).reshape(t, h)[:, np.newaxis, :]
     assert np.allclose(expected_data, result.data)
 
-    mesh_coord_x, mesh_coord_y = mesh.to_MeshCoords(Constants.Location.FACE)
+    mesh_coord_x, mesh_coord_y = mesh.to_MeshCoords("face")
     expected_cube = Cube(expected_data)
     expected_cube.add_dim_coord(time, 0)
     expected_cube.add_aux_coord(mesh_coord_x, 1)

--- a/esmf_regrid/tests/unit/experimental/unstructured_scheme/test_GridToMeshESMFRegridder.py
+++ b/esmf_regrid/tests/unit/experimental/unstructured_scheme/test_GridToMeshESMFRegridder.py
@@ -7,6 +7,7 @@ import numpy as np
 from numpy import ma
 import pytest
 
+from esmf_regrid._constants import Constants
 from esmf_regrid.experimental.unstructured_scheme import (
     GridToMeshESMFRegridder,
 )
@@ -74,7 +75,7 @@ def test_flat_cubes():
     assert expected_cube == result_transposed
 
 
-@pytest.mark.parametrize("method", ["bilinear", "nearest"])
+@pytest.mark.parametrize("method", [Constants.Method.BILINEAR, Constants.Method.NEAREST])
 def test_node_friendly_methods(method):
     """
     Basic test for :class:`esmf_regrid.experimental.unstructured_scheme.GridToMeshESMFRegridder`.
@@ -152,7 +153,7 @@ def test_multidim_cubes():
     expected_data[:] = np.arange(t * h).reshape(t, h)[:, np.newaxis, :]
     assert np.allclose(expected_data, result.data)
 
-    mesh_coord_x, mesh_coord_y = mesh.to_MeshCoords("face")
+    mesh_coord_x, mesh_coord_y = mesh.to_MeshCoords(Constants.Location.FACE)
     expected_cube = Cube(expected_data)
     expected_cube.add_dim_coord(time, 0)
     expected_cube.add_aux_coord(mesh_coord_x, 1)
@@ -202,7 +203,7 @@ def test_invalid_method():
     with pytest.raises(NotImplementedError):
         _ = GridToMeshESMFRegridder(src, face_tgt, method="other")
     with pytest.raises(ValueError) as excinfo:
-        _ = GridToMeshESMFRegridder(src, node_tgt, method="conservative")
+        _ = GridToMeshESMFRegridder(src, node_tgt, method=Constants.Method.CONSERVATIVE)
     expected_message = (
         "Conservative regridding requires a target cube located on "
         "the face of a cube, target cube had the node location."

--- a/esmf_regrid/tests/unit/experimental/unstructured_scheme/test_MeshToGridESMFRegridder.py
+++ b/esmf_regrid/tests/unit/experimental/unstructured_scheme/test_MeshToGridESMFRegridder.py
@@ -68,12 +68,12 @@ def test_flat_cubes():
     assert expected_cube == result
 
 
-@pytest.mark.parametrize("method", ["bilinear", "nearest"])
+@pytest.mark.parametrize("method", [Constants.Method.BILINEAR, Constants.Method.NEAREST])
 def test_node_friendly_methods(method):
     """
     Basic test for :class:`esmf_regrid.experimental.unstructured_scheme.MeshToGridESMFRegridder`.
 
-    Tests with method="bilinear" and method="nearest".
+    Tests with method=Constants.Method.BILINEAR and method=Constants.Method.NEAREST.
     """
     n_lons = 6
     n_lats = 5
@@ -197,21 +197,21 @@ def test_invalid_method():
     with pytest.raises(NotImplementedError):
         _ = MeshToGridESMFRegridder(face_src, tgt, method="other")
     with pytest.raises(ValueError) as excinfo:
-        _ = MeshToGridESMFRegridder(node_src, tgt, method="conservative")
+        _ = MeshToGridESMFRegridder(node_src, tgt, method=Constants.Method.CONSERVATIVE)
     expected_message = (
         "Conservative regridding requires a source cube located on "
         "the face of a cube, target cube had the node location."
     )
     assert expected_message in str(excinfo.value)
     with pytest.raises(ValueError) as excinfo:
-        _ = MeshToGridESMFRegridder(edge_src, tgt, method="bilinear")
+        _ = MeshToGridESMFRegridder(edge_src, tgt, method=Constants.Method.BILINEAR)
     expected_message = (
         "bilinear regridding requires a source cube with a node "
         "or face location, target cube had the edge location."
     )
     assert expected_message in str(excinfo.value)
     with pytest.raises(ValueError) as excinfo:
-        _ = MeshToGridESMFRegridder(edge_src, tgt, method="nearest")
+        _ = MeshToGridESMFRegridder(edge_src, tgt, method=Constants.Method.NEAREST)
     expected_message = (
         "nearest regridding requires a source cube with a node "
         "or face location, target cube had the edge location."
@@ -233,12 +233,12 @@ def test_invalid_resolution():
     tgt = _grid_cube(n_lons, n_lats, lon_bounds, lat_bounds, circular=True)
 
     with pytest.raises(ValueError) as excinfo:
-        _ = MeshToGridESMFRegridder(src, tgt, method="conservative", tgt_resolution=-1)
+        _ = MeshToGridESMFRegridder(src, tgt, method=Constants.Method.CONSERVATIVE, tgt_resolution=-1)
     expected_message = "resolution must be a positive integer."
     assert expected_message in str(excinfo.value)
 
     with pytest.raises(ValueError) as excinfo:
-        _ = MeshToGridESMFRegridder(src, tgt, method="bilinear", tgt_resolution=4)
+        _ = MeshToGridESMFRegridder(src, tgt, method=Constants.Method.BILINEAR, tgt_resolution=4)
     expected_message = "resolution can only be set for conservative regridding."
     assert expected_message in str(excinfo.value)
 
@@ -256,9 +256,9 @@ def test_default_mdtol():
     src = _gridlike_mesh_cube(n_lons, n_lats)
     tgt = _grid_cube(n_lons, n_lats, lon_bounds, lat_bounds, circular=True)
 
-    rg_con = MeshToGridESMFRegridder(src, tgt, method="conservative")
+    rg_con = MeshToGridESMFRegridder(src, tgt, method=Constants.Method.CONSERVATIVE)
     assert rg_con.mdtol == 1
-    rg_bi = MeshToGridESMFRegridder(src, tgt, method="bilinear")
+    rg_bi = MeshToGridESMFRegridder(src, tgt, method=Constants.Method.BILINEAR)
     assert rg_bi.mdtol == 0
 
 

--- a/esmf_regrid/tests/unit/experimental/unstructured_scheme/test_MeshToGridESMFRegridder.py
+++ b/esmf_regrid/tests/unit/experimental/unstructured_scheme/test_MeshToGridESMFRegridder.py
@@ -6,6 +6,7 @@ from iris.cube import Cube
 import numpy as np
 import pytest
 
+from esmf_regrid import Constants
 from esmf_regrid.experimental.unstructured_scheme import (
     MeshToGridESMFRegridder,
 )

--- a/esmf_regrid/tests/unit/experimental/unstructured_scheme/test_regrid_rectilinear_to_unstructured.py
+++ b/esmf_regrid/tests/unit/experimental/unstructured_scheme/test_regrid_rectilinear_to_unstructured.py
@@ -6,6 +6,7 @@ import numpy as np
 from numpy import ma
 import pytest
 
+from esmf_regrid import Constants
 from esmf_regrid.experimental.unstructured_scheme import (
     regrid_rectilinear_to_unstructured,
 )

--- a/esmf_regrid/tests/unit/experimental/unstructured_scheme/test_regrid_rectilinear_to_unstructured.py
+++ b/esmf_regrid/tests/unit/experimental/unstructured_scheme/test_regrid_rectilinear_to_unstructured.py
@@ -70,7 +70,7 @@ def test_flat_cubes():
     assert expected_cube == result_transposed
 
 
-@pytest.mark.parametrize("method", ("bilinear", "nearest"))
+@pytest.mark.parametrize("method", (Constants.Method.BILINEAR, Constants.Method.NEAREST))
 def test_node_friendly_methods(method):
     """
     Basic test for :func:`esmf_regrid.experimental.unstructured_scheme.regrid_rectilinear_to_unstructured`.
@@ -118,25 +118,25 @@ def test_invalid_args():
     src = _grid_cube(n_lons, n_lats, lon_bounds, lat_bounds, circular=True)
 
     with pytest.raises(ValueError):
-        _ = regrid_rectilinear_to_unstructured(src, src, method="bilinear")
+        _ = regrid_rectilinear_to_unstructured(src, src, method=Constants.Method.BILINEAR)
     with pytest.raises(NotImplementedError):
         _ = regrid_rectilinear_to_unstructured(src, face_tgt, method="other")
     with pytest.raises(ValueError) as excinfo:
-        _ = regrid_rectilinear_to_unstructured(src, node_tgt, method="conservative")
+        _ = regrid_rectilinear_to_unstructured(src, node_tgt, method=Constants.Method.CONSERVATIVE)
     expected_message = (
         "Conservative regridding requires a target cube located on "
         "the face of a cube, target cube had the node location."
     )
     assert expected_message in str(excinfo.value)
     with pytest.raises(ValueError) as excinfo:
-        _ = regrid_rectilinear_to_unstructured(src, edge_tgt, method="bilinear")
+        _ = regrid_rectilinear_to_unstructured(src, edge_tgt, method=Constants.Method.BILINEAR)
     expected_message = (
         "bilinear regridding requires a target cube with a node "
         "or face location, target cube had the edge location."
     )
     assert expected_message in str(excinfo.value)
     with pytest.raises(ValueError) as excinfo:
-        _ = regrid_rectilinear_to_unstructured(src, edge_tgt, method="nearest")
+        _ = regrid_rectilinear_to_unstructured(src, edge_tgt, method=Constants.Method.NEAREST)
     expected_message = (
         "nearest regridding requires a target cube with a node "
         "or face location, target cube had the edge location."

--- a/esmf_regrid/tests/unit/experimental/unstructured_scheme/test_regrid_unstructured_to_rectilinear.py
+++ b/esmf_regrid/tests/unit/experimental/unstructured_scheme/test_regrid_unstructured_to_rectilinear.py
@@ -64,7 +64,7 @@ def test_flat_cubes():
     assert expected_cube == result
 
 
-@pytest.mark.parametrize("method", ("bilinear", "nearest"))
+@pytest.mark.parametrize("method", (Constants.Method.BILINEAR, Constants.Method.NEAREST))
 def test_node_friendly_methods(method):
     """
     Basic test for :func:`esmf_regrid.experimental.unstructured_scheme.regrid_unstructured_to_rectilinear`.
@@ -112,25 +112,25 @@ def test_invalid_args():
     tgt = _grid_cube(n_lons, n_lats, lon_bounds, lat_bounds, circular=True)
 
     with pytest.raises(ValueError):
-        _ = regrid_unstructured_to_rectilinear(tgt, tgt, method="bilinear")
+        _ = regrid_unstructured_to_rectilinear(tgt, tgt, method=Constants.Method.BILINEAR)
     with pytest.raises(NotImplementedError):
         _ = regrid_unstructured_to_rectilinear(face_src, tgt, method="other")
     with pytest.raises(ValueError) as excinfo:
-        _ = regrid_unstructured_to_rectilinear(node_src, tgt, method="conservative")
+        _ = regrid_unstructured_to_rectilinear(node_src, tgt, method=Constants.Method.CONSERVATIVE)
     expected_message = (
         "Conservative regridding requires a source cube located on "
         "the face of a cube, target cube had the node location."
     )
     assert expected_message in str(excinfo.value)
     with pytest.raises(ValueError) as excinfo:
-        _ = regrid_unstructured_to_rectilinear(edge_src, tgt, method="bilinear")
+        _ = regrid_unstructured_to_rectilinear(edge_src, tgt, method=Constants.Method.BILINEAR)
     expected_message = (
         "bilinear regridding requires a source cube with a node "
         "or face location, target cube had the edge location."
     )
     assert expected_message in str(excinfo.value)
     with pytest.raises(ValueError) as excinfo:
-        _ = regrid_unstructured_to_rectilinear(edge_src, tgt, method="nearest")
+        _ = regrid_unstructured_to_rectilinear(edge_src, tgt, method=Constants.Method.NEAREST)
     expected_message = (
         "nearest regridding requires a source cube with a node "
         "or face location, target cube had the edge location."

--- a/esmf_regrid/tests/unit/experimental/unstructured_scheme/test_regrid_unstructured_to_rectilinear.py
+++ b/esmf_regrid/tests/unit/experimental/unstructured_scheme/test_regrid_unstructured_to_rectilinear.py
@@ -5,6 +5,7 @@ from iris.cube import Cube
 import numpy as np
 import pytest
 
+from esmf_regrid import Constants
 from esmf_regrid.experimental.unstructured_scheme import (
     regrid_unstructured_to_rectilinear,
 )

--- a/esmf_regrid/tests/unit/schemes/test__ESMFRegridder.py
+++ b/esmf_regrid/tests/unit/schemes/test__ESMFRegridder.py
@@ -20,5 +20,5 @@ def test_invalid_method():
     lat_bounds = (-90, 90)
     src = tgt = _grid_cube(n_lons, n_lats, lon_bounds, lat_bounds, circular=True)
 
-    with pytest.raises(NotImplementedError):
+    with pytest.raises(ValueError):
         _ = _ESMFRegridder(src, tgt, method="other")

--- a/esmf_regrid/tests/unit/schemes/test__mesh_to_MeshInfo.py
+++ b/esmf_regrid/tests/unit/schemes/test__mesh_to_MeshInfo.py
@@ -7,7 +7,6 @@ import numpy as np
 from numpy import ma
 import scipy.sparse
 
-from esmf_regrid import Constants
 from esmf_regrid.esmf_regridder import Regridder
 from esmf_regrid.schemes import _mesh_to_MeshInfo
 

--- a/esmf_regrid/tests/unit/schemes/test__mesh_to_MeshInfo.py
+++ b/esmf_regrid/tests/unit/schemes/test__mesh_to_MeshInfo.py
@@ -7,6 +7,7 @@ import numpy as np
 from numpy import ma
 import scipy.sparse
 
+from esmf_regrid import Constants
 from esmf_regrid.esmf_regridder import Regridder
 from esmf_regrid.schemes import _mesh_to_MeshInfo
 
@@ -191,7 +192,7 @@ def _gridlike_mesh(n_lons, n_lats):
     return mesh
 
 
-def _gridlike_mesh_cube(n_lons, n_lats, location="face"):
+def _gridlike_mesh_cube(n_lons, n_lats, location=Constants.Location.FACE):
     mesh = _gridlike_mesh(n_lons, n_lats)
     mesh_coord_x, mesh_coord_y = mesh.to_MeshCoords(location)
     data = np.zeros_like(mesh_coord_x.points)
@@ -204,7 +205,7 @@ def _gridlike_mesh_cube(n_lons, n_lats, location="face"):
 def test__mesh_to_MeshInfo():
     """Basic test for :func:`esmf_regrid.experimental.unstructured_scheme._mesh_to_MeshInfo`."""
     mesh = _example_mesh()
-    meshinfo = _mesh_to_MeshInfo(mesh, location="face")
+    meshinfo = _mesh_to_MeshInfo(mesh, location=Constants.Location.FACE)
 
     expected_nodes = np.array(
         [
@@ -228,7 +229,7 @@ def test__mesh_to_MeshInfo():
 def test_anticlockwise_validity():
     """Test validity of objects derived from Mesh objects with anticlockwise orientation."""
     mesh = _example_mesh()
-    meshinfo = _mesh_to_MeshInfo(mesh, location="face")
+    meshinfo = _mesh_to_MeshInfo(mesh, location=Constants.Location.FACE)
 
     # Ensure conversion to ESMF works without error.
     _ = meshinfo.make_esmf_field()
@@ -244,7 +245,7 @@ def test_anticlockwise_validity():
 def test_large_mesh_validity():
     """Test validity of objects derived from a large gridlike Mesh."""
     mesh = _gridlike_mesh(40, 20)
-    meshinfo = _mesh_to_MeshInfo(mesh, location="face")
+    meshinfo = _mesh_to_MeshInfo(mesh, location=Constants.Location.FACE)
 
     # Ensure conversion to ESMF works without error.
     _ = meshinfo.make_esmf_field()

--- a/esmf_regrid/tests/unit/schemes/test__mesh_to_MeshInfo.py
+++ b/esmf_regrid/tests/unit/schemes/test__mesh_to_MeshInfo.py
@@ -192,7 +192,7 @@ def _gridlike_mesh(n_lons, n_lats):
     return mesh
 
 
-def _gridlike_mesh_cube(n_lons, n_lats, location=Constants.Location.FACE):
+def _gridlike_mesh_cube(n_lons, n_lats, location="face"):
     mesh = _gridlike_mesh(n_lons, n_lats)
     mesh_coord_x, mesh_coord_y = mesh.to_MeshCoords(location)
     data = np.zeros_like(mesh_coord_x.points)
@@ -205,7 +205,7 @@ def _gridlike_mesh_cube(n_lons, n_lats, location=Constants.Location.FACE):
 def test__mesh_to_MeshInfo():
     """Basic test for :func:`esmf_regrid.experimental.unstructured_scheme._mesh_to_MeshInfo`."""
     mesh = _example_mesh()
-    meshinfo = _mesh_to_MeshInfo(mesh, location=Constants.Location.FACE)
+    meshinfo = _mesh_to_MeshInfo(mesh, location="face")
 
     expected_nodes = np.array(
         [
@@ -229,7 +229,7 @@ def test__mesh_to_MeshInfo():
 def test_anticlockwise_validity():
     """Test validity of objects derived from Mesh objects with anticlockwise orientation."""
     mesh = _example_mesh()
-    meshinfo = _mesh_to_MeshInfo(mesh, location=Constants.Location.FACE)
+    meshinfo = _mesh_to_MeshInfo(mesh, location="face")
 
     # Ensure conversion to ESMF works without error.
     _ = meshinfo.make_esmf_field()
@@ -245,7 +245,7 @@ def test_anticlockwise_validity():
 def test_large_mesh_validity():
     """Test validity of objects derived from a large gridlike Mesh."""
     mesh = _gridlike_mesh(40, 20)
-    meshinfo = _mesh_to_MeshInfo(mesh, location=Constants.Location.FACE)
+    meshinfo = _mesh_to_MeshInfo(mesh, location="face")
 
     # Ensure conversion to ESMF works without error.
     _ = meshinfo.make_esmf_field()

--- a/esmf_regrid/tests/unit/schemes/test__regrid_unstructured_to_rectilinear__prepare.py
+++ b/esmf_regrid/tests/unit/schemes/test__regrid_unstructured_to_rectilinear__prepare.py
@@ -61,7 +61,7 @@ def test_flat_cubes():
     lat_bounds = (-90, 90)
     tgt = _grid_cube(n_lons, n_lats, lon_bounds, lat_bounds, circular=True)
     regrid_info = _regrid_unstructured_to_rectilinear__prepare(
-        src, tgt, method="conservative"
+        src, tgt, method=Constants.Method.CONSERVATIVE
     )
     (mesh_dim,), (grid_x, grid_y), regridder = regrid_info
 

--- a/esmf_regrid/tests/unit/schemes/test__regrid_unstructured_to_rectilinear__prepare.py
+++ b/esmf_regrid/tests/unit/schemes/test__regrid_unstructured_to_rectilinear__prepare.py
@@ -4,6 +4,7 @@ from iris.coords import AuxCoord
 from iris.cube import Cube
 import numpy as np
 
+from esmf_regrid import Constants
 from esmf_regrid.esmf_regridder import GridInfo
 from esmf_regrid.experimental.unstructured_regrid import MeshInfo
 from esmf_regrid.schemes import (


### PR DESCRIPTION
Closes #263.

The introduction of enums in place of user inputs makes future edits easier for developers, and lowers chance of user error.

The current intention is to include the enum classes as a Class Attribute, so that users aren't required to import them independently. 

- [x]  esmf-regridder
- [x] schemes
   - [x] different structure and usage 
- [x] unstructured-regrid
- [x] unstructured-scheme?
-----
- [ ] tgt/src
- [ ] tests

