### PR TITLE
ASV v0.6 - no longer use strict parameter

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -432,7 +432,6 @@ def benchmarks(
                 merge_base,
                 "HEAD",
                 f"--factor={COMPARE_FACTOR}",
-                "--strict",
             ]
             session.run(*asv_command, *asv_args)
         finally:


### PR DESCRIPTION
## ❗ Merge once ASV `v0.6` has been released

The `--strict` parameter is being removed from ASV in the imminent `v0.6` release (airspeed-velocity/asv#1205) - it is becoming the default behaviour.