### PR TITLE
Add CITATION.cff

### DIFF
--- a/.github/workflows/ci-citation.yml
+++ b/.github/workflows/ci-citation.yml
@@ -1,0 +1,33 @@
+name: ci-citation
+
+on:
+  pull_request:
+    paths:
+      - "CITATION.cff"
+
+  push:
+    paths:
+      - "CITATION.cff"
+
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    name: "validate"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: "check CITATION.cff"
+        uses: citation-file-format/cffconvert-github-action@2.0.0
+        with:
+          args: "--validate"

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,12 @@
+cff-version: 1.2.0
+message: "If you use this software, please cite it as below."
+authors:
+- family-names: "Worsley"
+  given-names: "Stephen"
+  orcid: "https://orcid.org/0009-0008-1704-8445"
+title: "iris-esmf-regrid"
+abstract: "A collection of structured and unstructured ESMF regridding schemes for Iris"
+repository-code: "https://github.com/SciTools-incubator/iris-esmf-regrid"
+license: "BSD-3-Clause"
+license-url: "https://spdx.org/licenses/BSD-3-Clause.html"
+type: "software"

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -6,6 +6,7 @@ exclude .gitignore
 exclude .pre-commit-config.yaml
 exclude .readthedocs.yml
 include CHANGELOG.md
+include CITATION.cff
 prune benchmarks
 exclude codecov.yml
 prune docs

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Build Status](https://api.cirrus-ci.com/github/SciTools-incubator/iris-esmf-regrid.svg)](https://cirrus-ci.com/github/SciTools-incubator/iris-esmf-regrid)
 [![Documentation Status](https://readthedocs.org/projects/iris-esmf-regrid/badge/?version=latest)](https://iris-esmf-regrid.readthedocs.io/en/latest/?badge=latest)
+[![ci-citation](https://github.com/SciTools-incubator/iris-esmf-regrid/actions/workflows/ci-citation.yml/badge.svg)](https://github.com/SciTools-incubator/iris-esmf-regrid/actions/workflows/ci-citation.yml)
 [![pre-commit.ci status](https://results.pre-commit.ci/badge/github/SciTools-incubator/iris-esmf-regrid/main.svg)](https://results.pre-commit.ci/latest/github/SciTools-incubator/iris-esmf-regrid/master)
 [![codecov](https://codecov.io/gh/SciTools-incubator/iris-esmf-regrid/branch/main/graph/badge.svg?token=PKBXEHOZFT)](https://codecov.io/gh/SciTools-incubator/iris-esmf-regrid)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)


### PR DESCRIPTION
This pull-request adds a `CITATION.cff` to the repository so that it may be cited in academic publications.

Note that, it also includes a citation GHA that parses the `CITATION.cff` file when it is altered in a pull-request or push to ensure that it is valid.

Reference:
- [GitHub Docs - About CITATION files](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-citation-files)
- [What is a CITATION.cff file?](https://citation-file-format.github.io/)
- [Citation File Format](https://github.com/citation-file-format/citation-file-format/tree/main#citation-file-format)

Closes https://github.com/SciTools-incubator/iris-esmf-regrid/issues/309