### PR TITLE
Fix asv with custom build

### DIFF
--- a/benchmarks/asv.conf.json
+++ b/benchmarks/asv.conf.json
@@ -6,6 +6,10 @@
     "environment_type": "conda-delegated",
     "show_commit_url": "https://github.com/SciTools-incubator/iris-esmf-regrid/commit/",
     "branches": ["upstream/main"],
+    "build_command": [
+        "python setup.py build",
+        "python -mpip wheel --no-deps -w {build_cache_dir} {build_dir}"
+    ],
 
     "benchmark_dir": "./benchmarks",
     "env_dir": ".asv/env",


### PR DESCRIPTION
Fixes asv by implementing a `build_command` in `asv.conf.json` to use the `setup.py` file. Copies a simplified version of https://github.com/SciTools/iris/pull/5776