### PR TITLE
Adapt to changes in iris structure

### DIFF
--- a/benchmarks/benchmarks/esmf_regridder/__init__.py
+++ b/benchmarks/benchmarks/esmf_regridder/__init__.py
@@ -6,9 +6,9 @@ from pathlib import Path
 import dask.array as da
 import iris
 from iris.cube import Cube
-from iris.experimental.ugrid import PARSE_UGRID_ON_LOAD
 import numpy as np
 
+from esmf_regrid import _load_context
 from esmf_regrid.esmf_regridder import GridInfo
 from esmf_regrid.experimental.unstructured_scheme import (
     GridToMeshESMFRegridder,
@@ -252,7 +252,7 @@ class TimeLazyMeshToGridRegridding:
 
         iris.save(src, file, chunksizes=chunk_size)
         # Construct regridder with a loaded version of the grid for consistency.
-        with PARSE_UGRID_ON_LOAD.context():
+        with _load_context():
             loaded_src = iris.load_cube(file)
         regridder = MeshToGridESMFRegridder(loaded_src, tgt)
 
@@ -261,7 +261,7 @@ class TimeLazyMeshToGridRegridding:
     def setup(self, cache):
         """ASV setup method."""
         regridder, file = cache
-        with PARSE_UGRID_ON_LOAD.context():
+        with _load_context():
             self.src = iris.load_cube(file)
             cube = iris.load_cube(file)
         self.result = regridder(cube)

--- a/benchmarks/benchmarks/generate_data.py
+++ b/benchmarks/benchmarks/generate_data.py
@@ -22,7 +22,8 @@ from textwrap import dedent
 from warnings import warn
 
 from iris import load_cube
-from iris.experimental.ugrid import PARSE_UGRID_ON_LOAD
+
+from esmf_regrid import _load_context
 
 #: Python executable used by :func:`run_function_elsewhere`, set via env
 #:  variable of same name. Must be path of Python within an environment that
@@ -253,6 +254,6 @@ def _gridlike_mesh_cube(n_lons, n_lats):
             save_path=str(save_path),
         )
 
-    with PARSE_UGRID_ON_LOAD.context():
+    with _load_context():
         return_cube = load_cube(str(save_path))
     return return_cube

--- a/esmf_regrid/__init__.py
+++ b/esmf_regrid/__init__.py
@@ -7,6 +7,19 @@ except ImportError as exc:
     except ImportError:
         raise exc
 
+try:
+    import iris.mesh as _imesh
+except ImportError as exc:
+    try:
+        import iris.experimental.ugrid as _imesh
+    except ImportError:
+        raise exc
+if hasattr(_imesh, "PARSE_UGRID_ON_LOAD"):
+    _load_context = _imesh.PARSE_UGRID_ON_LOAD
+else:
+    from contextlib import nullcontext
+    _load_context = nullcontext
+
 # constants needs to be above schemes, as it is used within
 from .constants import Constants, check_method, check_norm
 from .schemes import *

--- a/esmf_regrid/__init__.py
+++ b/esmf_regrid/__init__.py
@@ -14,7 +14,7 @@ except ImportError as exc:
         import iris.experimental.ugrid as _imesh
     except ImportError:
         raise exc
-     
+
 if hasattr(_imesh, "PARSE_UGRID_ON_LOAD"):
     _load_context = _imesh.PARSE_UGRID_ON_LOAD
 else:

--- a/esmf_regrid/__init__.py
+++ b/esmf_regrid/__init__.py
@@ -14,6 +14,7 @@ except ImportError as exc:
         import iris.experimental.ugrid as _imesh
     except ImportError:
         raise exc
+     
 if hasattr(_imesh, "PARSE_UGRID_ON_LOAD"):
     _load_context = _imesh.PARSE_UGRID_ON_LOAD
 else:

--- a/esmf_regrid/experimental/io.py
+++ b/esmf_regrid/experimental/io.py
@@ -5,11 +5,11 @@ from contextlib import contextmanager
 import iris
 from iris.coords import AuxCoord
 from iris.cube import Cube, CubeList
-from iris.experimental.ugrid import PARSE_UGRID_ON_LOAD
 import numpy as np
 import scipy.sparse
 
 import esmf_regrid
+from esmf_regrid import _load_context
 from esmf_regrid import check_method, Constants
 from esmf_regrid.experimental.unstructured_scheme import (
     GridToMeshESMFRegridder,
@@ -288,7 +288,7 @@ def load_regridder(filename):
     -------
     :class:`~esmf_regrid.experimental.unstructured_scheme.GridToMeshESMFRegridder` or :class:`~esmf_regrid.experimental.unstructured_scheme.MeshToGridESMFRegridder`
     """
-    with PARSE_UGRID_ON_LOAD.context():
+    with _load_context():
         cubes = iris.load(filename)
 
     # Extract the source, target and metadata information.

--- a/esmf_regrid/experimental/unstructured_scheme.py
+++ b/esmf_regrid/experimental/unstructured_scheme.py
@@ -1,14 +1,13 @@
 """Provides an iris interface for unstructured regridding."""
 
 try:
-    from iris.experimental.ugrid import MeshXY
+    from iris.mesh import MeshXY
 except ImportError as exc:
     # Prior to v3.10.0, `MeshXY` could was named `Mesh`.
     try:
         from iris.experimental.ugrid import Mesh as MeshXY
     except ImportError:
         raise exc
-
 from esmf_regrid import check_method, Constants
 from esmf_regrid.schemes import (
     _ESMFRegridder,

--- a/esmf_regrid/schemes.py
+++ b/esmf_regrid/schemes.py
@@ -11,7 +11,7 @@ from iris.exceptions import CoordinateNotFoundError
 import numpy as np
 
 try:
-    from iris.experimental.ugrid import MeshXY
+    from iris.mesh import MeshXY
 except ImportError as exc:
     # Prior to v3.10.0, `MeshXY` could was named `Mesh`.
     try:

--- a/esmf_regrid/tests/integration/experimental/unstructured_scheme/test_regrid_unstructured_to_rectilinear.py
+++ b/esmf_regrid/tests/integration/experimental/unstructured_scheme/test_regrid_unstructured_to_rectilinear.py
@@ -3,8 +3,13 @@
 import os
 
 import iris
-from iris.experimental.ugrid import PARSE_UGRID_ON_LOAD
 import numpy as np
+try:
+    from iris.experimental.ugrid import PARSE_UGRID_ON_LOAD
+    _load_context = PARSE_UGRID_ON_LOAD.context
+except ImportError:
+    from contextlib import nullcontext
+    _load_context = nullcontext
 
 from esmf_regrid.experimental.unstructured_scheme import (
     regrid_unstructured_to_rectilinear,
@@ -22,7 +27,7 @@ def test_real_data():
     src_fn = os.path.join(
         test_data_dir, "NetCDF", "unstructured_grid", "lfric_surface_mean.nc"
     )
-    with PARSE_UGRID_ON_LOAD.context():
+    with _load_context():
         src = iris.load_cube(src_fn, "rainfall_flux")
 
     # Load target grid cube.

--- a/esmf_regrid/tests/unit/schemes/test__mesh_to_MeshInfo.py
+++ b/esmf_regrid/tests/unit/schemes/test__mesh_to_MeshInfo.py
@@ -8,7 +8,7 @@ from numpy import ma
 import scipy.sparse
 
 try:
-    from iris.experimental.ugrid import MeshXY
+    from iris.mesh import MeshXY
 except ImportError as exc:
     # Prior to v3.10.0, `MeshXY` could was named `Mesh`.
     try:


### PR DESCRIPTION
Adapt to the movement of `iris.experimental.ugrid` to `iris.mesh`.